### PR TITLE
Add prune command

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
           cache: false
       - name: GolangCi-Lint
         uses: golangci/golangci-lint-action@v6.1.1
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
 
       - name: Test
         run: go test -v ./...
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: GolangCi-Lint
         uses: golangci/golangci-lint-action@v6.1.1
         with:
-          version: v1.59.1
+          version: v1.62.0
           args: --timeout=5m
   test:
     name: Test

--- a/commands/prune.go
+++ b/commands/prune.go
@@ -135,7 +135,7 @@ var PruneCommand = discord.SlashCommandCreate{
 			},
 			Required: true,
 
-			MinValue: utils.Ref(0),
+			MinValue: utils.Ref(3),
 			MaxValue: utils.Ref(90),
 		},
 	},

--- a/commands/prune.go
+++ b/commands/prune.go
@@ -1,0 +1,258 @@
+package commands
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/handler"
+	"github.com/disgoorg/disgo/rest"
+	"github.com/disgoorg/json"
+
+	"github.com/myrkvi/heimdallr/globals"
+	"github.com/myrkvi/heimdallr/model"
+	"github.com/myrkvi/heimdallr/utils"
+)
+
+var PruneDryRunCommand = discord.SlashCommandCreate{
+	Name: "prune-pending-members-dry-run",
+	NameLocalizations: map[discord.Locale]string{
+		discord.LocaleNorwegian: "fjern-ventende-medlemmer-dry-run",
+	},
+	Description: "Prune members.",
+	DescriptionLocalizations: map[discord.Locale]string{
+		discord.LocaleNorwegian: "Fjern medlemmer.",
+	},
+
+	Contexts: []discord.InteractionContextType{
+		discord.InteractionContextTypeGuild,
+	},
+	IntegrationTypes: []discord.ApplicationIntegrationType{
+		discord.ApplicationIntegrationTypeGuildInstall,
+	},
+
+	DefaultMemberPermissions: json.NewNullablePtr(discord.PermissionManageGuild),
+
+	Options: []discord.ApplicationCommandOption{
+		discord.ApplicationCommandOptionInt{
+			Name: "days",
+			NameLocalizations: map[discord.Locale]string{
+				discord.LocaleNorwegian: "dager",
+			},
+			Description: "The number of days to prune members for.",
+			DescriptionLocalizations: map[discord.Locale]string{
+				discord.LocaleNorwegian: "Antall dager å fjerne medlemmer for.",
+			},
+			Required: true,
+
+			MinValue: utils.Ref(0),
+			MaxValue: utils.Ref(90),
+		},
+	},
+}
+
+func PruneDryRunHandler(e *handler.CommandEvent) error {
+	if e.GuildID() == nil {
+		return ErrEventNoGuildID
+	}
+	days := e.SlashCommandInteractionData().Int("days")
+
+	guildSettings, err := model.GetGuildSettings(*e.GuildID())
+	if err != nil {
+		_ = e.CreateMessage(discord.NewMessageCreateBuilder().
+			SetEphemeral(true).
+			SetContent("Failed to prune members: could not get guild settings.").
+			Build())
+		return err
+	}
+
+	if guildSettings.GatekeepPendingRole == 0 {
+		return e.CreateMessage(discord.NewMessageCreateBuilder().
+			SetEphemeral(true).
+			SetContent("Failed to prune members: no pending role set. This command will only prune pending members.").
+			Build())
+	}
+
+	_ = e.DeferCreateMessage(true)
+
+	prunableMembers, err := getPrunableMembers(e, days, guildSettings)
+	if err != nil {
+		_, err = e.CreateFollowupMessage(discord.NewMessageCreateBuilder().
+			SetEphemeral(true).
+			SetContent("Failed to prune members: could not get member list.").
+			Build())
+		return err
+	}
+
+	numKicked := len(prunableMembers)
+
+	adminMessage := fmt.Sprintf("Dry run: pruned %d members.\n\nMembers:\n", numKicked)
+
+	for _, member := range prunableMembers {
+		if member == nil {
+			continue
+		}
+
+		adminMessage += fmt.Sprintf("-# %s (%s)\n", member.User.Username, member.User.ID)
+	}
+
+	_, err = e.CreateFollowupMessage(discord.NewMessageCreateBuilder().
+		SetEphemeral(true).
+		SetContent(adminMessage).
+		Build())
+	return err
+}
+
+var PruneCommand = discord.SlashCommandCreate{
+	Name: "prune-pending-members",
+	NameLocalizations: map[discord.Locale]string{
+		discord.LocaleNorwegian: "fjern-ventende-medlemmer",
+	},
+	Description: "Prune members.",
+	DescriptionLocalizations: map[discord.Locale]string{
+		discord.LocaleNorwegian: "Fjern medlemmer.",
+	},
+
+	Contexts: []discord.InteractionContextType{
+		discord.InteractionContextTypeGuild,
+	},
+	IntegrationTypes: []discord.ApplicationIntegrationType{
+		discord.ApplicationIntegrationTypeGuildInstall,
+	},
+
+	DefaultMemberPermissions: json.NewNullablePtr(discord.PermissionManageGuild),
+
+	Options: []discord.ApplicationCommandOption{
+		discord.ApplicationCommandOptionInt{
+			Name: "days",
+			NameLocalizations: map[discord.Locale]string{
+				discord.LocaleNorwegian: "dager",
+			},
+			Description: "The number of days to prune members for.",
+			DescriptionLocalizations: map[discord.Locale]string{
+				discord.LocaleNorwegian: "Antall dager å fjerne medlemmer for.",
+			},
+			Required: true,
+
+			MinValue: utils.Ref(0),
+			MaxValue: utils.Ref(90),
+		},
+	},
+}
+
+func PruneHandler(e *handler.CommandEvent) error {
+	if e.GuildID() == nil {
+		return ErrEventNoGuildID
+	}
+	days := e.SlashCommandInteractionData().Int("days")
+
+	guildSettings, err := model.GetGuildSettings(*e.GuildID())
+	if err != nil {
+		_ = e.CreateMessage(discord.NewMessageCreateBuilder().
+			SetEphemeral(true).
+			SetContent("Failed to prune members: could not get guild settings.").
+			Build())
+		return err
+	}
+
+	if guildSettings.GatekeepPendingRole == 0 {
+		return e.CreateMessage(discord.NewMessageCreateBuilder().
+			SetEphemeral(true).
+			SetContent("Failed to prune members: no pending role set. This command will only prune pending members.").
+			Build())
+	}
+
+	_ = e.DeferCreateMessage(true)
+
+	var kickedMembers []*discord.Member
+
+	prunableMembers, err := getPrunableMembers(e, days, guildSettings)
+	if err != nil {
+		_, err = e.CreateFollowupMessage(discord.NewMessageCreateBuilder().
+			SetEphemeral(true).
+			SetContent("Failed to prune members: could not get member list.").
+			Build())
+		return err
+	}
+
+	for _, member := range prunableMembers {
+
+		globals.ExcludedFromModKickLog[member.User.ID] = struct{}{}
+		kickedMembers = append(kickedMembers, member)
+
+		err = e.Client().Rest().RemoveMember(*e.GuildID(), member.User.ID,
+			rest.WithReason(
+				fmt.Sprintf("User pruned with command. Pruned by: %s (%s)",
+					e.User().Username, e.User().ID)))
+		if err != nil {
+			slog.Error("Failed to prune member.", "err", err, "user_id", member.User.ID)
+			_, err = e.CreateFollowupMessage(discord.NewMessageCreateBuilder().
+				SetEphemeral(true).
+				SetContent("Failed to prune members: failed to remove member.").
+				Build())
+			return err
+		}
+	}
+
+	numKicked := len(kickedMembers)
+
+	adminMessage := fmt.Sprintf("Pruned %d members.\n\nMembers:\n", numKicked)
+
+	for _, member := range kickedMembers {
+		if member == nil {
+			continue
+		}
+
+		adminMessage += fmt.Sprintf("-# %s (%s)\n", member.User.Username, member.User.ID)
+	}
+
+	if numKicked > 0 && guildSettings.ModeratorChannel != 0 {
+		_, err = e.Client().Rest().CreateMessage(guildSettings.ModeratorChannel, discord.NewMessageCreateBuilder().
+			SetContent(adminMessage).
+			SetEphemeral(true).
+			Build())
+		if err != nil {
+			slog.Error("Failed to send prune message to moderator channel.",
+				"err", err,
+				"guild_id", *e.GuildID(),
+				"channel_id", guildSettings.ModeratorChannel,
+				"user_id", e.User().ID)
+		}
+	}
+
+	_ = days
+
+	_, err = e.CreateFollowupMessage(discord.NewMessageCreateBuilder().
+		SetEphemeral(true).
+		SetContentf("Pruned %d users.", numKicked).
+		Build())
+	return err
+}
+
+func getPrunableMembers(e *handler.CommandEvent, days int, guildSettings *model.GuildSettings) (members []*discord.Member, err error) {
+	maxTimeDiff := time.Duration(days) * time.Hour * 24
+
+	for member := range utils.GetMembersIter(e.Client().Rest(), *e.GuildID()) {
+		if member.Error != nil {
+			return nil, member.Error
+		}
+		member := member.Value
+
+		if !utils.HasRole(member, guildSettings.GatekeepPendingRole) {
+			continue
+		}
+
+		if utils.HasRole(member, guildSettings.GatekeepApprovedRole) {
+			continue
+		}
+
+		if time.Since(member.JoinedAt) < maxTimeDiff {
+			continue
+		}
+
+		members = append(members, &member)
+	}
+
+	return
+}

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -1,0 +1,5 @@
+package globals
+
+import "github.com/disgoorg/snowflake/v2"
+
+var ExcludedFromModKickLog = make(map[snowflake.ID]struct{})

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/myrkvi/heimdallr
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/cbroglie/mustache v1.4.0

--- a/listeners/audit_log.go
+++ b/listeners/audit_log.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/disgoorg/disgo/discord"
 	"github.com/disgoorg/disgo/events"
+
+	"github.com/myrkvi/heimdallr/globals"
 	"github.com/myrkvi/heimdallr/model"
 	"github.com/myrkvi/heimdallr/utils"
 )
@@ -23,6 +25,13 @@ func OnAuditLog(e *events.GuildAuditLogEntryCreate) {
 		user, err := e.Client().Rest().GetUser(entry.UserID)
 		if err != nil {
 			slog.Warn("Failed to get user for audit log entry.", "err", err, "user_id", entry.UserID)
+			return
+		}
+
+		if _, ok := globals.ExcludedFromModKickLog[targetUser.ID]; ok {
+			// User is excluded from mod kick log, likely because they were pruned.
+			// Remove from excluded list and don't log.
+			delete(globals.ExcludedFromModKickLog, targetUser.ID)
 			return
 		}
 

--- a/main.go
+++ b/main.go
@@ -115,6 +115,9 @@ func main() {
 	r.Command("/create-role-button", commands.CreateRoleButtonHandler)
 	r.Component("/role/assign/{roleID}", components.RoleAssignButtonHandler)
 
+	r.Command("/prune-pending-members", commands.PruneHandler)
+	r.Command("/prune-pending-members-dry-run", commands.PruneDryRunHandler)
+
 	commandCreates := []discord.ApplicationCommandCreate{
 		commands.PingCommand,
 		commands.QuoteCommand,
@@ -127,6 +130,8 @@ func main() {
 		commands.ApproveSlashCommand,
 		commands.ApproveUserCommand,
 		commands.CreateRoleButtonCommand,
+		commands.PruneCommand,
+		commands.PruneDryRunCommand,
 	}
 
 	client, err := disgo.New(token,

--- a/utils/users.go
+++ b/utils/users.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/snowflake/v2"
+)
+
+func HasRole(member discord.Member, roleID snowflake.ID) bool {
+	for _, role := range member.RoleIDs {
+		if role == roleID {
+			return true
+		}
+	}
+
+	return false
+}
+
+func HasRolesAll(member discord.Member, roleIDs ...snowflake.ID) bool {
+	hasRole := make(map[snowflake.ID]bool)
+	for _, role := range member.RoleIDs {
+		hasRole[role] = false
+	}
+	for _, role := range member.RoleIDs {
+		for _, roleID := range roleIDs {
+			if role == roleID {
+				hasRole[role] = true
+			}
+		}
+	}
+
+	for _, hasRole := range hasRole {
+		if !hasRole {
+			return false
+		}
+	}
+
+	return true
+}
+
+func HasRolesAny(member discord.Member, roleIDs ...snowflake.ID) bool {
+	for _, role := range member.RoleIDs {
+		for _, roleID := range roleIDs {
+			if role == roleID {
+				return true
+			}
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Adds a prune command to automate pruning of pending members. Also added a dry run command to see who will be pruned before running it. Those will likely be merged later, but wanted to be certain that the dry run had absolutely no logic to kick within its handler for the first tries in production, while otherwise sharing code that filters which members are valid for pruning.