### PR TITLE
Upgrade to Go 1.24

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,9 +17,9 @@ jobs:
           go-version: "1.24"
           cache: false
       - name: GolangCi-Lint
-        uses: golangci/golangci-lint-action@v6.4.1
+        uses: golangci/golangci-lint-action@v6.5.0
         with:
-          version: v1.62.0
+          version: v1.64.5
           args: --timeout=5m
   test:
     name: Test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           cache: false
       - name: GolangCi-Lint
         uses: golangci/golangci-lint-action@v6.4.1
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Test
         run: go test -v ./...
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Build
         run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NLLCommunity/heimdallr
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/agnivade/levenshtein v1.2.1


### PR DESCRIPTION
Upgrades Go to version 1.24 in go.mod and GitHub workflows. Dockerfile already uses 1.24 to build.