### PR TITLE
Reset option for admin commands

### DIFF
--- a/interactions/admin/anti_spam.go
+++ b/interactions/admin/anti_spam.go
@@ -35,6 +35,17 @@ var antiSpamSubcommand = discord.ApplicationCommandOptionSubCommand{
 			MinValue:    utils.Ref(1),
 			MaxValue:    utils.Ref(60),
 		},
+		discord.ApplicationCommandOptionString{
+			Name:        "reset",
+			Description: "Reset a setting to its default value",
+			Required:    false,
+			Choices: []discord.ApplicationCommandOptionChoiceString{
+				{Name: "Enabled", Value: "enabled"},
+				{Name: "Count", Value: "count"},
+				{Name: "Cooldown", Value: "cooldown"},
+				{Name: "All", Value: "all"},
+			},
+		},
 	},
 }
 
@@ -79,6 +90,26 @@ func AdminAntiSpamHandler(e *handler.CommandEvent) error {
 
 	message := ""
 
+	resetOption, hasReset := data.OptString("reset")
+	if hasReset {
+		switch resetOption {
+		case "enabled":
+			settings.AntiSpamEnabled = false
+			message += "Anti-spam enabled has been reset.\n"
+		case "count":
+			settings.AntiSpamCount = 5 // Default value
+			message += "Anti-spam count has been reset.\n"
+		case "cooldown":
+			settings.AntiSpamCooldownSeconds = 20 // Default value
+			message += "Anti-spam cooldown has been reset.\n"
+		case "all":
+			settings.AntiSpamEnabled = false
+			settings.AntiSpamCount = 5            // Default value
+			settings.AntiSpamCooldownSeconds = 20 // Default value
+			message += "All anti-spam settings have been reset.\n"
+		}
+	}
+
 	enabled, hasEnabled := data.OptBool("enabled")
 	if hasEnabled {
 		settings.AntiSpamEnabled = enabled
@@ -97,7 +128,7 @@ func AdminAntiSpamHandler(e *handler.CommandEvent) error {
 		message += fmt.Sprintf("Anti-spam cooldown (seconds) set to %d\n", cooldown)
 	}
 
-	if !utils.Any(hasEnabled, hasCount, hasCooldown) {
+	if !utils.Any(hasEnabled, hasCount, hasCooldown, hasReset) {
 		return e.CreateMessage(interactions.EphemeralMessageContent(antiSpamInfo(settings)).Build())
 	}
 

--- a/interactions/admin/gatekeep.go
+++ b/interactions/admin/gatekeep.go
@@ -135,14 +135,16 @@ func gatekeepInfo(settings *model.GuildSettings) string {
 
 	gatekeepPendingRoleInfo := "> This is the role given to users pending approval."
 	gatekeepPendingRole := fmt.Sprintf(
-		"**Gatekeep pending role:** <@&%d>\n%s",
-		settings.GatekeepPendingRole, gatekeepPendingRoleInfo,
+		"**Gatekeep pending role:** %s\n%s",
+		utils.MentionRoleOrDefault(&settings.GatekeepPendingRole, "not set"),
+		gatekeepPendingRoleInfo,
 	)
 
 	gatekeepApprovedRoleInfo := "> This is the role given to approved users."
 	gatekeepApprovedRole := fmt.Sprintf(
-		"**Gatekeep approved role:** <@&%d>\n%s",
-		settings.GatekeepApprovedRole, gatekeepApprovedRoleInfo,
+		"**Gatekeep approved role:** %s\n%s",
+		utils.MentionRoleOrDefault(&settings.GatekeepApprovedRole, "not set"),
+		gatekeepApprovedRoleInfo,
 	)
 
 	gatekeepAddPendingRoleOnJoinInfo := "> This determines whether to give the pending role to users when they join."

--- a/interactions/admin/gatekeep.go
+++ b/interactions/admin/gatekeep.go
@@ -35,6 +35,18 @@ var gatekeepSubcommand = discord.ApplicationCommandOptionSubCommand{
 			Description: "Whether to give the pending role to users when they join",
 			Required:    false,
 		},
+		discord.ApplicationCommandOptionString{
+			Name:        "reset",
+			Description: "Reset a setting to its default value",
+			Required:    false,
+			Choices: []discord.ApplicationCommandOptionChoiceString{
+				{Name: "Enabled", Value: "enabled"},
+				{Name: "Pending role", Value: "pending-role"},
+				{Name: "Approved role", Value: "approved-role"},
+				{Name: "Use pending role", Value: "use-pending-role"},
+				{Name: "All", Value: "all"},
+			},
+		},
 	},
 }
 
@@ -53,6 +65,30 @@ func AdminGatekeepHandler(e *handler.CommandEvent) error {
 	}
 
 	message := ""
+
+	resetOption, hasReset := data.OptString("reset")
+	if hasReset {
+		switch resetOption {
+		case "enabled":
+			settings.GatekeepEnabled = false
+			message += "Gatekeep enabled has been reset.\n"
+		case "pending-role":
+			settings.GatekeepPendingRole = 0
+			message += "Gatekeep pending role has been reset.\n"
+		case "approved-role":
+			settings.GatekeepApprovedRole = 0
+			message += "Gatekeep approved role has been reset.\n"
+		case "use-pending-role":
+			settings.GatekeepAddPendingRoleOnJoin = false
+			message += "Give pending role on join has been reset.\n"
+		case "all":
+			settings.GatekeepEnabled = false
+			settings.GatekeepPendingRole = 0
+			settings.GatekeepApprovedRole = 0
+			settings.GatekeepAddPendingRoleOnJoin = false
+			message += "All gatekeep settings have been reset.\n"
+		}
+	}
 
 	enabled, hasEnabled := data.OptBool("enabled")
 	if hasEnabled {
@@ -78,7 +114,7 @@ func AdminGatekeepHandler(e *handler.CommandEvent) error {
 		message += fmt.Sprintf("Give pending role on join set to %s\n", utils.Iif(usePendingRole, "yes", "no"))
 	}
 
-	if !utils.Any(hasEnabled, hasPendingRole, hasApprovedRole, hasUsePendingRole) {
+	if !utils.Any(hasEnabled, hasPendingRole, hasApprovedRole, hasUsePendingRole, hasReset) {
 		return e.CreateMessage(interactions.EphemeralMessageContent(gatekeepInfo(settings)).Build())
 	}
 

--- a/interactions/admin/infractions.go
+++ b/interactions/admin/infractions.go
@@ -34,6 +34,17 @@ var infractionsSubCommand = discord.ApplicationCommandOptionSubCommand{
 			MinValue:    utils.Ref(0.0),
 			MaxValue:    utils.Ref(100.0),
 		},
+		discord.ApplicationCommandOptionString{
+			Name:        "reset",
+			Description: "Reset a setting to its default value",
+			Required:    false,
+			Choices: []discord.ApplicationCommandOptionChoiceString{
+				{Name: "Half-life", Value: "half-life"},
+				{Name: "Notify on warned user join", Value: "notify-warned-user-join"},
+				{Name: "Notify threshold", Value: "notify-threshold"},
+				{Name: "All", Value: "all"},
+			},
+		},
 	},
 }
 
@@ -50,6 +61,26 @@ func AdminInfractionsHandler(e *handler.CommandEvent) error {
 	}
 
 	message := ""
+
+	resetOption, hasReset := data.OptString("reset")
+	if hasReset {
+		switch resetOption {
+		case "half-life":
+			settings.InfractionHalfLifeDays = 0
+			message += "Infraction half-life has been reset.\n"
+		case "notify-warned-user-join":
+			settings.NotifyOnWarnedUserJoin = false
+			message += "Notify on warned user join has been reset.\n"
+		case "notify-threshold":
+			settings.NotifyWarnSeverityThreshold = 0
+			message += "Notify warn severity threshold has been reset.\n"
+		case "all":
+			settings.InfractionHalfLifeDays = 0
+			settings.NotifyOnWarnedUserJoin = false
+			settings.NotifyWarnSeverityThreshold = 0
+			message += "All infraction settings have been reset.\n"
+		}
+	}
 
 	halfLife, hasHalfLife := data.OptFloat("half-life")
 	if hasHalfLife {
@@ -69,7 +100,7 @@ func AdminInfractionsHandler(e *handler.CommandEvent) error {
 		message += fmt.Sprintf("Notify warn severity threshold set to %.1f\n", notifyThreshold)
 	}
 
-	if !utils.Any(hasHalfLife, hasNotifyThreshold, hasNotifyOnWarnedUserJoin) {
+	if !utils.Any(hasHalfLife, hasNotifyThreshold, hasNotifyOnWarnedUserJoin, hasReset) {
 		return e.CreateMessage(interactions.EphemeralMessageContent(infractionInfo(settings)).Build())
 	}
 

--- a/interactions/admin/join_leave.go
+++ b/interactions/admin/join_leave.go
@@ -126,8 +126,9 @@ func joinLeaveInfo(settings *model.GuildSettings) string {
 
 	joinLeaveChannelInfo := "> This is the channel in which join and leave messages are sent."
 	joinLeaveChannel := fmt.Sprintf(
-		"**Join/leave channel:** <#%d>\n%s",
-		settings.JoinLeaveChannel, joinLeaveChannelInfo,
+		"**Join/leave channel:** %s\n%s",
+		utils.MentionChannelOrDefault(&settings.JoinLeaveChannel, "not set"),
+		joinLeaveChannelInfo,
 	)
 
 	joinLeaveMessageInfo := "The join/leave messages can be viewed by using the `/admin join-message` and `/admin leave-message` commands."

--- a/interactions/admin/join_leave.go
+++ b/interactions/admin/join_leave.go
@@ -31,6 +31,17 @@ var joinLeaveSubcommand = discord.ApplicationCommandOptionSubCommand{
 			Required:     false,
 			ChannelTypes: []discord.ChannelType{discord.ChannelTypeGuildText},
 		},
+		discord.ApplicationCommandOptionString{
+			Name:        "reset",
+			Description: "Reset a setting to its default value",
+			Required:    false,
+			Choices: []discord.ApplicationCommandOptionChoiceString{
+				{Name: "Join enabled", Value: "join-enabled"},
+				{Name: "Leave enabled", Value: "leave-enabled"},
+				{Name: "Channel", Value: "channel"},
+				{Name: "All", Value: "all"},
+			},
+		},
 	},
 }
 
@@ -49,25 +60,46 @@ func AdminJoinLeaveHandler(e *handler.CommandEvent) error {
 
 	message := ""
 
-	joinEnabled, hasJoinEnabled := e.SlashCommandInteractionData().OptBool("join-enabled")
+	data := e.SlashCommandInteractionData()
+	resetOption, hasReset := data.OptString("reset")
+	if hasReset {
+		switch resetOption {
+		case "join-enabled":
+			settings.JoinMessageEnabled = false
+			message += "Join message enabled has been reset.\n"
+		case "leave-enabled":
+			settings.LeaveMessageEnabled = false
+			message += "Leave message enabled has been reset.\n"
+		case "channel":
+			settings.JoinLeaveChannel = 0
+			message += "Join/leave channel has been reset.\n"
+		case "all":
+			settings.JoinMessageEnabled = false
+			settings.LeaveMessageEnabled = false
+			settings.JoinLeaveChannel = 0
+			message += "All join/leave settings have been reset.\n"
+		}
+	}
+
+	joinEnabled, hasJoinEnabled := data.OptBool("join-enabled")
 	if hasJoinEnabled {
 		settings.JoinMessageEnabled = joinEnabled
 		message += fmt.Sprintf("Join message enabled set to %s\n", utils.Iif(joinEnabled, "yes", "no"))
 	}
 
-	leaveEnabled, hasLeaveEnabled := e.SlashCommandInteractionData().OptBool("leave-enabled")
+	leaveEnabled, hasLeaveEnabled := data.OptBool("leave-enabled")
 	if hasLeaveEnabled {
 		settings.LeaveMessageEnabled = leaveEnabled
 		message += fmt.Sprintf("Leave message enabled set to %s\n", utils.Iif(leaveEnabled, "yes", "no"))
 	}
 
-	channel, hasChannel := e.SlashCommandInteractionData().OptChannel("channel")
+	channel, hasChannel := data.OptChannel("channel")
 	if hasChannel {
 		settings.JoinLeaveChannel = channel.ID
 		message += fmt.Sprintf("Join/leave channel set to <#%d>\n", channel.ID)
 	}
 
-	if !utils.Any(hasJoinEnabled, hasLeaveEnabled, hasChannel) {
+	if !utils.Any(hasJoinEnabled, hasLeaveEnabled, hasChannel, hasReset) {
 		return e.CreateMessage(interactions.EphemeralMessageContent(joinLeaveInfo(settings)).Build())
 	}
 

--- a/interactions/admin/mod_channel.go
+++ b/interactions/admin/mod_channel.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NLLCommunity/heimdallr/interactions"
 	"github.com/NLLCommunity/heimdallr/model"
+	"github.com/NLLCommunity/heimdallr/utils"
 )
 
 var modChannelSubcommand = discord.ApplicationCommandOptionSubCommand{
@@ -73,7 +74,8 @@ func AdminModChannelHandler(e *handler.CommandEvent) error {
 func modChannelInfo(settings *model.GuildSettings) string {
 	modChannelInfo := "> This is the channel in which notifications and other information for moderators and administrators are sent."
 	return fmt.Sprintf(
-		"**Moderator channel:** <#%d>\n%s",
-		settings.ModeratorChannel, modChannelInfo,
+		"**Moderator channel:** %s\n%s",
+		utils.MentionChannelOrDefault(&settings.ModeratorChannel, "not set"),
+		modChannelInfo,
 	)
 }

--- a/interactions/modmail/modmail.go
+++ b/interactions/modmail/modmail.go
@@ -110,7 +110,7 @@ func ModmailSettingsHandler(e *handler.CommandEvent) error {
 	}
 	if notificationChannelOK {
 		settings.ReportNotificationChannel = notificationChannel.ID
-		message += fmt.Sprintf("Notification Channel set to <#%s>\n", reportChannel.ID)
+		message += fmt.Sprintf("Notification Channel set to <#%s>\n", notificationChannel.ID)
 	}
 
 	err = model.SetModmailSettings(settings)

--- a/interactions/modmail/modmail.go
+++ b/interactions/modmail/modmail.go
@@ -85,6 +85,10 @@ func ModmailSettingsHandler(e *handler.CommandEvent) error {
 	}
 
 	if !reportChannelOK && !pingRoleOK && !notificationChannelOK && !resetOptionOK {
+		reportThreadsChannel := utils.MentionChannelOrDefault(&settings.ReportThreadsChannel, "not set")
+		reportNotificationChannel := utils.MentionChannelOrDefault(&settings.ReportNotificationChannel, "not set")
+		reportPingRole := utils.MentionRoleOrDefault(&settings.ReportPingRole, "not set")
+
 		return e.CreateMessage(
 			ix.EphemeralMessageContentf(
 				"## Modmail Settings\n"+
@@ -95,21 +99,9 @@ func ModmailSettingsHandler(e *handler.CommandEvent) error {
 					"**Ping Role:** %s\n"+
 					"> Role that will be pinged when a new thread is created.",
 
-				utils.Iif(
-					settings.ReportThreadsChannel != 0,
-					fmt.Sprintf("<#%s>", settings.ReportThreadsChannel),
-					"not set",
-				),
-				utils.Iif(
-					settings.ReportNotificationChannel != 0,
-					fmt.Sprintf("<#%s>", settings.ReportNotificationChannel),
-					"not set",
-				),
-				utils.Iif(
-					settings.ReportPingRole != 0,
-					fmt.Sprintf("<@&%s>", settings.ReportPingRole),
-					"not set",
-				),
+				reportThreadsChannel,
+				reportNotificationChannel,
+				reportPingRole,
 			).
 				Build(),
 		)

--- a/utils/mentions.go
+++ b/utils/mentions.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/disgoorg/snowflake/v2"
+)
+
+// MentionRoleOrDefault formats a mention for a role by its ID. If the ID
+// pointer is nil or zero, use a provided fallback value instead.
+func MentionRoleOrDefault(id *snowflake.ID, def string) string {
+	if id == nil || *id == 0 {
+		return def
+	}
+
+	return fmt.Sprintf("<@&%d>", *id)
+}
+
+// MentionChannelOrDefault formats a mention for a channel by its ID. If the ID
+// pointer is nil or zero, use a provided fallback value instead.
+func MentionChannelOrDefault(id *snowflake.ID, def string) string {
+	if id == nil || *id == 0 {
+		return def
+	}
+
+	return fmt.Sprintf("<#%d>", *id)
+}


### PR DESCRIPTION
Adds the option to reset various fields in the `/admin` sub-commands. Previously not possible.