### PR TITLE
fix(ban): Don't create temp ban if duration is 0

### DIFF
--- a/interactions/ban/ban.go
+++ b/interactions/ban/ban.go
@@ -162,9 +162,11 @@ func BanHandler(e *handler.CommandEvent) error {
 		return err
 	}
 
-	_, err = model.CreateTempBan(*e.GuildID(), user.ID, e.User().ID, reason, time.Now().Add(dur))
-	if err != nil {
-		return err
+	if dur > 0 {
+		_, err = model.CreateTempBan(*e.GuildID(), user.ID, e.User().ID, reason, time.Now().Add(dur))
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -69,6 +69,8 @@ var LongDurationRegex = regexp.MustCompile(`^(?:(?P<years>\d+)y)? *(?:(?P<months
 // ParseLongDuration parses a string into a time.Duration.
 // It supports the following format:
 //   - 1y2mo3w4d5h6m3s (year, month, week, day, hour, minute, second)
+//
+// Note: an empty duration string will be a duration of 0.
 func ParseLongDuration(s string) (time.Duration, error) {
 	names := LongDurationRegex.SubexpNames()
 	matches := LongDurationRegex.FindStringSubmatch(s)


### PR DESCRIPTION
Fixed a regression in which it will create a temp ban of duration zero when using the bot's ban command, due to how the empty duration string is parsed.