### PR TITLE
fix: Set integration types to be guild-only

### DIFF
--- a/interactions/admin/admin.go
+++ b/interactions/admin/admin.go
@@ -45,6 +45,7 @@ var AdminCommand = discord.SlashCommandCreate{
 	Description:              "admin commands",
 	DefaultMemberPermissions: json.NewNullablePtr(discord.PermissionAdministrator),
 	Contexts:                 []discord.InteractionContextType{discord.InteractionContextTypeGuild},
+	IntegrationTypes:         []discord.ApplicationIntegrationType{discord.ApplicationIntegrationTypeGuildInstall},
 	Options: []discord.ApplicationCommandOption{
 		discord.ApplicationCommandOptionSubCommand{
 			Name:        "info",

--- a/interactions/ban/ban.go
+++ b/interactions/ban/ban.go
@@ -27,6 +27,7 @@ var BanCommand = discord.SlashCommandCreate{
 	Name:                     "ban",
 	Description:              "Ban a user from the server",
 	DMPermission:             utils.Ref(false),
+	IntegrationTypes:         []discord.ApplicationIntegrationType{discord.ApplicationIntegrationTypeGuildInstall},
 	DefaultMemberPermissions: json.NewNullablePtr(discord.PermissionBanMembers),
 	Options: []discord.ApplicationCommandOption{
 

--- a/interactions/gatekeep/slash_command.go
+++ b/interactions/gatekeep/slash_command.go
@@ -14,6 +14,7 @@ var ApproveSlashCommand = discord.SlashCommandCreate{
 	Name:                     "approve",
 	Description:              "Approve a user to join the server",
 	DefaultMemberPermissions: json.NewNullablePtr(discord.PermissionKickMembers),
+	IntegrationTypes:         []discord.ApplicationIntegrationType{discord.ApplicationIntegrationTypeGuildInstall},
 	Contexts: []discord.InteractionContextType{
 		discord.InteractionContextTypeGuild,
 	},

--- a/interactions/gatekeep/user_command.go
+++ b/interactions/gatekeep/user_command.go
@@ -13,6 +13,7 @@ import (
 var ApproveUserCommand = discord.UserCommandCreate{
 	Name:                     "Approve",
 	DefaultMemberPermissions: json.NewNullablePtr(discord.PermissionKickMembers),
+	IntegrationTypes:         []discord.ApplicationIntegrationType{discord.ApplicationIntegrationTypeGuildInstall},
 	Contexts: []discord.InteractionContextType{
 		discord.InteractionContextTypeGuild,
 	},

--- a/interactions/infractions/infractions_command.go
+++ b/interactions/infractions/infractions_command.go
@@ -27,6 +27,7 @@ var InfractionsCommand = discord.SlashCommandCreate{
 	},
 
 	DMPermission:             utils.Ref(false),
+	IntegrationTypes:         []discord.ApplicationIntegrationType{discord.ApplicationIntegrationTypeGuildInstall},
 	DefaultMemberPermissions: json.NewNullablePtr(discord.PermissionKickMembers),
 	Options: []discord.ApplicationCommandOption{
 		discord.ApplicationCommandOptionSubCommand{

--- a/interactions/infractions/warn_command.go
+++ b/interactions/infractions/warn_command.go
@@ -26,6 +26,7 @@ var WarnCommand = discord.SlashCommandCreate{
 	},
 
 	DMPermission:             utils.Ref(false),
+	IntegrationTypes:         []discord.ApplicationIntegrationType{discord.ApplicationIntegrationTypeGuildInstall},
 	DefaultMemberPermissions: json.NewNullablePtr(discord.PermissionKickMembers),
 	Options: []discord.ApplicationCommandOption{
 		discord.ApplicationCommandOptionUser{

--- a/interactions/infractions/warnings_command.go
+++ b/interactions/infractions/warnings_command.go
@@ -23,7 +23,8 @@ var UserInfractionsCommand = discord.SlashCommandCreate{
 		discord.LocaleNorwegian: "Se advarslene dine.",
 	},
 
-	DMPermission: utils.Ref(false),
+	DMPermission:     utils.Ref(false),
+	IntegrationTypes: []discord.ApplicationIntegrationType{discord.ApplicationIntegrationTypeGuildInstall},
 }
 
 func UserInfractionsHandler(e *handler.CommandEvent) error {

--- a/interactions/kick/kick.go
+++ b/interactions/kick/kick.go
@@ -26,6 +26,7 @@ var KickCommand = discord.SlashCommandCreate{
 	Name:                     "kick",
 	Description:              "Kick a user from the server",
 	DMPermission:             utils.Ref(false),
+	IntegrationTypes:         []discord.ApplicationIntegrationType{discord.ApplicationIntegrationTypeGuildInstall},
 	DefaultMemberPermissions: json.NewNullablePtr(discord.PermissionKickMembers),
 	Options: []discord.ApplicationCommandOption{
 		discord.ApplicationCommandOptionSubCommand{

--- a/interactions/modmail/modmail.go
+++ b/interactions/modmail/modmail.go
@@ -30,6 +30,7 @@ var ModmailAdminCommand = discord.SlashCommandCreate{
 	Name:                     "modmail-admin",
 	Description:              "Commands for receiving and sending Modmail.",
 	DefaultMemberPermissions: json.NewNullablePtr(discord.PermissionKickMembers),
+	IntegrationTypes:         []discord.ApplicationIntegrationType{discord.ApplicationIntegrationTypeGuildInstall},
 	Contexts: []discord.InteractionContextType{
 		discord.InteractionContextTypeGuild,
 	},

--- a/interactions/role_button/create_command.go
+++ b/interactions/role_button/create_command.go
@@ -24,6 +24,7 @@ var CreateRoleButtonCommand = discord.SlashCommandCreate{
 
 	DMPermission:             utils.Ref(false),
 	DefaultMemberPermissions: json.NewNullablePtr(discord.PermissionManageRoles),
+	IntegrationTypes:         []discord.ApplicationIntegrationType{discord.ApplicationIntegrationTypeGuildInstall},
 
 	Options: []discord.ApplicationCommandOption{
 		discord.ApplicationCommandOptionRole{

--- a/model/deleted_message_log.go
+++ b/model/deleted_message_log.go
@@ -1,0 +1,1 @@
+package model


### PR DESCRIPTION
Previously this wasn't enforced, but seems to have been implicit for most commands, except for the `/modmail-admin` commands. This should now be enforced for all application commands.