### PR TITLE
feat: Added ban footer for ban DMs

### DIFF
--- a/interactions/admin/admin.go
+++ b/interactions/admin/admin.go
@@ -34,6 +34,10 @@ func Register(r *handler.Mux) []discord.ApplicationCommandCreate {
 			r.Modal("/leave-message/modal", AdminLeaveMessageModalHandler)
 
 			r.Command("/anti-spam", AdminAntiSpamHandler)
+
+			r.Command("/ban-footer", AdminBanFooterHandler)
+			r.Component("/ban-footer/button", AdminBanFooterButtonHandler)
+			r.Modal("/ban-footer/modal", AdminBanFooterModalHandler)
 		},
 	)
 
@@ -60,6 +64,7 @@ var AdminCommand = discord.SlashCommandCreate{
 		joinMessageSubcommand,
 		leaveMessageSubcommand,
 		antiSpamSubcommand,
+		banFooterSubcommand,
 	},
 }
 

--- a/interactions/admin/ban_footer.go
+++ b/interactions/admin/ban_footer.go
@@ -1,0 +1,123 @@
+package admin
+
+import (
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/handler"
+
+	ix "github.com/NLLCommunity/heimdallr/interactions"
+	"github.com/NLLCommunity/heimdallr/model"
+	"github.com/NLLCommunity/heimdallr/utils"
+)
+
+var banFooterSubcommand = discord.ApplicationCommandOptionSubCommand{
+	Name:        "ban-footer",
+	Description: "View or set the ban footer, shown at the end of DM sent when user is banned.",
+	Options: []discord.ApplicationCommandOption{
+		discord.ApplicationCommandOptionBool{
+			Name:        "always-send",
+			Description: "Whether to always send the footer, even if there is no ban message",
+		},
+		discord.ApplicationCommandOptionString{
+			Name:        "reset",
+			Description: "Reset the message to its default value",
+			Required:    false,
+			Choices: []discord.ApplicationCommandOptionChoiceString{
+				{Name: "Reset", Value: "reset"},
+			},
+		},
+	},
+}
+
+func AdminBanFooterHandler(e *handler.CommandEvent) error {
+	utils.LogInteraction("admin", e)
+	guild, isGuild := e.Guild()
+	if !isGuild {
+		return ix.ErrEventNoGuildID
+	}
+
+	data := e.SlashCommandInteractionData()
+	resetOption, hasReset := data.OptString("reset")
+	alwaysSend, hasAlwaysSend := data.OptBool("always-send")
+
+	settings, err := model.GetGuildSettings(guild.ID)
+	if err != nil {
+		return err
+	}
+
+	if hasAlwaysSend {
+		settings.AlwaysSendBanFooter = alwaysSend
+		err = model.SetGuildSettings(settings)
+		if err != nil {
+			return e.CreateMessage(ix.EphemeralMessageContent("Failed to save settings.").Build())
+		}
+		return e.CreateMessage(ix.EphemeralMessageContent("Settings saved.").Build())
+	}
+
+	if hasReset && resetOption == "reset" {
+		settings.BanFooter = ""
+		settings.AlwaysSendBanFooter = false
+		err = model.SetGuildSettings(settings)
+		if err != nil {
+			return err
+		}
+		return e.CreateMessage(ix.EphemeralMessageContent("Ban footer has been reset.").Build())
+	}
+
+	embed := discord.NewEmbedBuilder().
+		SetTitle("Ban footer").
+		SetDescription(utils.Iif(settings.BanFooter == "", "*no footer set*", settings.BanFooter)).
+		Build()
+
+	return e.CreateMessage(
+		ix.EphemeralMessageContentf("**Always send ban DM:** %s",
+			utils.Iif(settings.AlwaysSendBanFooter, "yes", "no")).
+			SetEmbeds(embed).
+			AddActionRow(discord.NewPrimaryButton("Edit message", "/admin/ban-footer/button")).
+			Build())
+}
+
+func AdminBanFooterButtonHandler(e *handler.ComponentEvent) error {
+	utils.LogInteraction("admin", e)
+
+	guild, isGuild := e.Guild()
+	if !isGuild {
+		return ix.ErrEventNoGuildID
+	}
+
+	settings, err := model.GetGuildSettings(guild.ID)
+	if err != nil {
+		return err
+	}
+
+	return e.Modal(
+		messageModal(
+			"/admin/ban-footer/modal",
+			"Ban footer",
+			settings.BanFooter,
+		),
+	)
+}
+
+func AdminBanFooterModalHandler(e *handler.ModalEvent) error {
+	utils.LogInteraction("admin", e)
+	guild, isGuild := e.Guild()
+	if !isGuild {
+		return ix.ErrEventNoGuildID
+	}
+
+	message := e.Data.Text("message")
+
+	settings, err := model.GetGuildSettings(guild.ID)
+	if err != nil {
+		return err
+	}
+
+	settings.BanFooter = message
+
+	err = model.SetGuildSettings(settings)
+	if err != nil {
+		return e.CreateMessage(ix.EphemeralMessageContent("Failed to update ban footer").Build())
+	}
+
+	return e.CreateMessage(ix.EphemeralMessageContent("Ban footer updated.").Build())
+}

--- a/interactions/modmail/button_modal_handler.go
+++ b/interactions/modmail/button_modal_handler.go
@@ -5,11 +5,12 @@ import (
 	"log/slog"
 	"strconv"
 
-	ix "github.com/NLLCommunity/heimdallr/interactions"
-	"github.com/NLLCommunity/heimdallr/utils"
 	"github.com/disgoorg/disgo/discord"
 	"github.com/disgoorg/disgo/handler"
 	"github.com/disgoorg/snowflake/v2"
+
+	ix "github.com/NLLCommunity/heimdallr/interactions"
+	"github.com/NLLCommunity/heimdallr/utils"
 )
 
 func ModmailReportModalHandler(e *handler.ModalEvent) error {
@@ -95,7 +96,7 @@ func ModmailReportModalHandler(e *handler.ModalEvent) error {
 	message, err := e.Client().Rest().CreateMessage(
 		thread.ID(),
 		discord.MessageCreate{
-			Content: fmt.Sprintf("||%s%s",
+			Content: fmt.Sprintf("%s%s",
 				utils.Iif(role != "0", fmt.Sprintf("<@&%s>", role), ""),
 				user.Mention()),
 			Embeds: []discord.Embed{embed},

--- a/model/guild_settings.go
+++ b/model/guild_settings.go
@@ -35,6 +35,9 @@ type GuildSettings struct {
 	AntiSpamEnabled         bool
 	AntiSpamCount           int `gorm:"default:5"`
 	AntiSpamCooldownSeconds int `gorm:"default:20"`
+
+	BanFooter           string
+	AlwaysSendBanFooter bool
 }
 
 func GetGuildSettings(guildID snowflake.ID) (*GuildSettings, error) {


### PR DESCRIPTION
Added a new "ban footer", which is a moderator-set text that is included when a ban DM is sent to the user. It can also be set to send it, even if there is no ban message or ban duration specified. The intended use is to be able to inform banned users of appeal policies and similar.

In the cases one wants to avoid informing people, when it sends out automatically, there is a new option in the ban command. Note that adding a ban message or setting a duration will still cause a DM to be sent, with the footer.

Adds a new "/admin ban-footer" sub-command. No parameters will result in current configuration being shown, with a button to open a modal to edit the message.
Modifies the "/ban" command, adding a new, optional parameter "dont-auto-dm".