### PR TITLE
feat: Use Discord V2 components for timeout mod message

### DIFF
--- a/listeners/antispam_message.go
+++ b/listeners/antispam_message.go
@@ -18,7 +18,7 @@ import (
 )
 
 const minMessageLength = 10
-const maxLevenshteinDistance = 5
+const maxLevenshteinDistancePercent = 5
 const maxMessages = 20
 
 var whitespaceReplacer = strings.NewReplacer(
@@ -136,7 +136,7 @@ func timeoutUser(e *events.GuildMessageCreate, guildSettings *model.GuildSetting
 		return
 	}
 
-	timeoutMessage, _ := timeoutMessage(e, info, len(removableMessageIDs))
+	timeoutMessage := createTimeoutMessage(e, removableMessageIDs, len(removableMessageIDs))
 
 	_, err = e.Client().Rest.CreateMessage(
 		guildSettings.ModeratorChannel, timeoutMessage,
@@ -157,41 +157,31 @@ type Mentioner interface {
 	Mention() string
 }
 
-func timeoutMessage(e *events.GuildMessageCreate, info userMessagesInfo, deletedCount int) (discord.MessageCreate, error) {
-	messages := make([]discord.ContainerSubComponent, len(info.Messages))
+func createTimeoutMessage(e *events.GuildMessageCreate, msgs []*messageDetails, deletedCount int) discord.MessageCreate {
+	messages := make([]discord.ContainerComponent, len(msgs))
 
-	for i, m := range info.Messages {
-		channel := "unknown channel"
-		ch, err := e.Client().Rest.GetChannel(m.ChannelID)
-		if err == nil {
-			if gch, ok := ch.(Mentioner); ok {
-				channel = gch.Mention()
-			} else {
-				channel = ch.Name()
-			}
-		} else {
-			slog.Warn(
-				"Failed to fetch channel for timeout message.",
-			)
-		}
+	for i, m := range msgs {
+		channel := fmt.Sprintf("<#%s>", m.ChannelID)
 
-		user := "unknown user"
-		if e.Message.Author.ID != 0 {
-			user = e.Message.Author.Mention()
-		}
-
-		messages[i] = discord.NewSection(
+		messages[i] = discord.NewContainer(
 			discord.NewTextDisplayf(">>> %s", m.Content),
-			discord.NewTextDisplayf("-# Channel: %s,    User: %s", channel, user),
+			discord.NewTextDisplayf("-# Channel: %s", channel),
 		)
 	}
 
-	message := discord.NewMessageCreateV2(
+	components := []discord.LayoutComponent{
 		discord.NewTextDisplayf("User %s has been timed out for spamming. Deleted %d messages.", e.Message.Author.Username, deletedCount),
-		discord.NewContainer(messages...),
+	}
+
+	for _, c := range messages {
+		components = append(components, c)
+	}
+
+	message := discord.NewMessageCreateV2(
+		components...,
 	)
 
-	return message, nil
+	return message
 }
 
 func compareToPreviousMessages(details *messageDetails, info userMessagesInfo) bool {
@@ -211,9 +201,13 @@ func compareToPreviousMessages(details *messageDetails, info userMessagesInfo) b
 		prevMessage := whitespaceReplacer.Replace(mInfo.Content)
 
 		distance := levenshtein.ComputeDistance(currentMessage, prevMessage)
-		if distance < maxLevenshteinDistance && details.ChannelID != mInfo.ChannelID {
+		maxLevenshteinDistance := int(float64(len(currentMessage)) * maxLevenshteinDistancePercent / 100)
+		if distance <= maxLevenshteinDistance && details.ChannelID != mInfo.ChannelID {
 			// Return true if these are similar messages across channels
+			slog.Info("Found similar message across channels.", "current_message", details.Content, "previous_message", mInfo.Content, "distance", distance)
 			return true
+		} else {
+			slog.Debug("Messages are not similar enough or are in the same channel.", "current_message", details.Content, "previous_message", mInfo.Content, "distance", distance)
 		}
 	}
 	return false

--- a/listeners/antispam_message.go
+++ b/listeners/antispam_message.go
@@ -3,6 +3,7 @@ package listeners
 import (
 	"fmt"
 	"log/slog"
+	"math"
 	"strings"
 	"time"
 
@@ -113,16 +114,16 @@ func timeoutUser(e *events.GuildMessageCreate, guildSettings *model.GuildSetting
 		return
 	}
 
-	var removableMessageIDs []*messageDetails
+	var removableMessages []*messageDetails
 	for _, m := range info.Messages {
 		if m.MessageID.Time().Before(cutoffTime) {
 			continue
 		}
 
-		removableMessageIDs = append(removableMessageIDs, m)
+		removableMessages = append(removableMessages, m)
 	}
 
-	for _, m := range removableMessageIDs {
+	for _, m := range removableMessages {
 		err := e.Client().Rest.DeleteMessage(m.ChannelID, m.MessageID)
 		if err != nil {
 			slog.Error(
@@ -136,7 +137,7 @@ func timeoutUser(e *events.GuildMessageCreate, guildSettings *model.GuildSetting
 		return
 	}
 
-	timeoutMessage := createTimeoutMessage(e, removableMessageIDs, len(removableMessageIDs))
+	timeoutMessage := createTimeoutMessage(e, removableMessages, len(removableMessages))
 
 	_, err = e.Client().Rest.CreateMessage(
 		guildSettings.ModeratorChannel, timeoutMessage,
@@ -178,7 +179,7 @@ func createTimeoutMessage(e *events.GuildMessageCreate, msgs []*messageDetails, 
 			content = content[:maxPerMessageContent] + truncationMarker
 		}
 		contentText := fmt.Sprintf(">>> %s", content)
-		channelText := fmt.Sprintf("-# Channel: <#%s>", m.ChannelID)
+		channelText := fmt.Sprintf("-# Channel: <#%d>", m.ChannelID)
 
 		// Each entry adds 1 container + 2 text displays.
 		const addComponents = 3
@@ -231,7 +232,8 @@ func compareToPreviousMessages(details *messageDetails, info userMessagesInfo) b
 		prevMessage := whitespaceReplacer.Replace(mInfo.Content)
 
 		distance := levenshtein.ComputeDistance(currentMessage, prevMessage)
-		maxLevenshteinDistance := int(float64(len(currentMessage)) * maxLevenshteinDistancePercent / 100)
+		messageLength := float64(len(currentMessage))
+		maxLevenshteinDistance := int(math.Ceil(messageLength * maxLevenshteinDistancePercent / 100))
 		if distance <= maxLevenshteinDistance && details.ChannelID != mInfo.ChannelID {
 			// Return true if these are similar messages across channels
 			slog.Info("Found similar message across channels.", "current_message", details.Content, "previous_message", mInfo.Content, "distance", distance)

--- a/listeners/antispam_message.go
+++ b/listeners/antispam_message.go
@@ -140,7 +140,7 @@ func timeoutUser(e *events.GuildMessageCreate, guildSettings *model.GuildSetting
 	timeoutMessage := createTimeoutMessage(e, removableMessages, len(removableMessages))
 
 	_, err = e.Client().Rest.CreateMessage(
-		guildSettings.ModeratorChannel, timeoutMessage,
+		guildSettings.ModeratorChannel, timeoutMessage.WithAllowedMentions(&discord.AllowedMentions{}),
 	)
 
 	if err != nil {
@@ -234,12 +234,12 @@ func compareToPreviousMessages(details *messageDetails, info userMessagesInfo) b
 		distance := levenshtein.ComputeDistance(currentMessage, prevMessage)
 		messageLength := float64(len(currentMessage))
 		maxLevenshteinDistance := int(math.Ceil(messageLength * maxLevenshteinDistancePercent / 100))
-		if distance <= maxLevenshteinDistance && details.ChannelID != mInfo.ChannelID {
-			// Return true if these are similar messages across channels
-			slog.Info("Found similar message across channels.", "current_message", details.Content, "previous_message", mInfo.Content, "distance", distance)
+		if distance <= maxLevenshteinDistance {
+			// Return true if these are similar messages
+			slog.Info("Found similar message.", "current_message", details.Content, "previous_message", mInfo.Content, "distance", distance)
 			return true
 		} else {
-			slog.Debug("Messages are not similar enough or are in the same channel.", "current_message", details.Content, "previous_message", mInfo.Content, "distance", distance)
+			slog.Debug("Messages are not similar enough.", "current_message", details.Content, "previous_message", mInfo.Content, "distance", distance)
 		}
 	}
 	return false

--- a/listeners/antispam_message.go
+++ b/listeners/antispam_message.go
@@ -153,35 +153,65 @@ func timeoutUser(e *events.GuildMessageCreate, guildSettings *model.GuildSetting
 	}
 }
 
-type Mentioner interface {
-	Mention() string
-}
+// Discord V2 component message limits.
+const (
+	maxTopLevelComponents = 10
+	maxTotalComponents    = 40
+	maxTotalTextLength    = 4000
+	maxPerMessageContent  = 500
+	truncationMarker      = "…"
+)
 
 func createTimeoutMessage(e *events.GuildMessageCreate, msgs []*messageDetails, deletedCount int) discord.MessageCreate {
-	messages := make([]discord.ContainerComponent, len(msgs))
+	summary := fmt.Sprintf("User %s has been timed out for spamming. Deleted %d messages.", e.Message.Author.Username, deletedCount)
+
+	components := []discord.LayoutComponent{discord.NewTextDisplay(summary)}
+	totalComponents := 1
+	totalText := len(summary)
+
+	const omissionReserveText = 64
+	omitted := 0
 
 	for i, m := range msgs {
-		channel := fmt.Sprintf("<#%s>", m.ChannelID)
+		content := m.Content
+		if len(content) > maxPerMessageContent {
+			content = content[:maxPerMessageContent] + truncationMarker
+		}
+		contentText := fmt.Sprintf(">>> %s", content)
+		channelText := fmt.Sprintf("-# Channel: <#%s>", m.ChannelID)
 
-		messages[i] = discord.NewContainer(
-			discord.NewTextDisplayf(">>> %s", m.Content),
-			discord.NewTextDisplayf("-# Channel: %s", channel),
-		)
+		// Each entry adds 1 container + 2 text displays.
+		const addComponents = 3
+		addText := len(contentText) + len(channelText)
+
+		// Reserve budget for a possible "N omitted" notice if there are more entries after this one.
+		reserveComponents := 0
+		reserveText := 0
+		if i < len(msgs)-1 {
+			reserveComponents = 1
+			reserveText = omissionReserveText
+		}
+
+		if len(components)+1+reserveComponents > maxTopLevelComponents ||
+			totalComponents+addComponents+reserveComponents > maxTotalComponents ||
+			totalText+addText+reserveText > maxTotalTextLength {
+			omitted = len(msgs) - i
+			break
+		}
+
+		components = append(components, discord.NewContainer(
+			discord.NewTextDisplay(contentText),
+			discord.NewTextDisplay(channelText),
+		))
+		totalComponents += addComponents
+		totalText += addText
 	}
 
-	components := []discord.LayoutComponent{
-		discord.NewTextDisplayf("User %s has been timed out for spamming. Deleted %d messages.", e.Message.Author.Username, deletedCount),
+	if omitted > 0 {
+		components = append(components, discord.NewTextDisplayf("-# … and %d more message(s) omitted.", omitted))
 	}
 
-	for _, c := range messages {
-		components = append(components, c)
-	}
-
-	message := discord.NewMessageCreateV2(
-		components...,
-	)
-
-	return message
+	return discord.NewMessageCreateV2(components...)
 }
 
 func compareToPreviousMessages(details *messageDetails, info userMessagesInfo) bool {

--- a/listeners/antispam_message.go
+++ b/listeners/antispam_message.go
@@ -81,6 +81,8 @@ func OnAntispamMessageCreate(e *events.GuildMessageCreate) {
 	messageDetails := createMessageDetails(e.Message)
 	info.Messages = append(info.Messages, messageDetails)
 
+	// Check if this message is similar to previous messages across channels
+	// matching minimum length and Levenshtein distance thresholds.
 	matchesPreviousMessage := compareToPreviousMessages(messageDetails, info)
 	if matchesPreviousMessage {
 		info.Score++
@@ -134,14 +136,10 @@ func timeoutUser(e *events.GuildMessageCreate, guildSettings *model.GuildSetting
 		return
 	}
 
-	adminMessage := fmt.Sprintf(
-		"User %s has been timed out for spamming. Deleted %d messages.\n\nTriggering message:\n>>> %s",
-		e.Message.Author.Mention(), len(removableMessageIDs), e.Message.Content,
-	)
+	timeoutMessage, _ := timeoutMessage(e, info, len(removableMessageIDs))
 
 	_, err = e.Client().Rest.CreateMessage(
-		guildSettings.ModeratorChannel, discord.NewMessageCreate().
-			WithContent(adminMessage),
+		guildSettings.ModeratorChannel, timeoutMessage,
 	)
 
 	if err != nil {
@@ -153,6 +151,47 @@ func timeoutUser(e *events.GuildMessageCreate, guildSettings *model.GuildSetting
 			"user", e.Message.Author.ID,
 		)
 	}
+}
+
+type Mentioner interface {
+	Mention() string
+}
+
+func timeoutMessage(e *events.GuildMessageCreate, info userMessagesInfo, deletedCount int) (discord.MessageCreate, error) {
+	messages := make([]discord.ContainerSubComponent, len(info.Messages))
+
+	for i, m := range info.Messages {
+		channel := "unknown channel"
+		ch, err := e.Client().Rest.GetChannel(m.ChannelID)
+		if err == nil {
+			if gch, ok := ch.(Mentioner); ok {
+				channel = gch.Mention()
+			} else {
+				channel = ch.Name()
+			}
+		} else {
+			slog.Warn(
+				"Failed to fetch channel for timeout message.",
+			)
+		}
+
+		user := "unknown user"
+		if e.Message.Author.ID != 0 {
+			user = e.Message.Author.Mention()
+		}
+
+		messages[i] = discord.NewSection(
+			discord.NewTextDisplayf(">>> %s", m.Content),
+			discord.NewTextDisplayf("-# Channel: %s,    User: %s", channel, user),
+		)
+	}
+
+	message := discord.NewMessageCreateV2(
+		discord.NewTextDisplayf("User %s has been timed out for spamming. Deleted %d messages.", e.Message.Author.Username, deletedCount),
+		discord.NewContainer(messages...),
+	)
+
+	return message, nil
 }
 
 func compareToPreviousMessages(details *messageDetails, info userMessagesInfo) bool {

--- a/listeners/antispam_message.go
+++ b/listeners/antispam_message.go
@@ -80,7 +80,6 @@ func OnAntispamMessageCreate(e *events.GuildMessageCreate) {
 	}
 
 	messageDetails := createMessageDetails(e.Message)
-	info.Messages = append(info.Messages, messageDetails)
 
 	// Check if this message is similar to previous messages across channels
 	// matching minimum length and Levenshtein distance thresholds.
@@ -88,6 +87,8 @@ func OnAntispamMessageCreate(e *events.GuildMessageCreate) {
 	if matchesPreviousMessage {
 		info.Score++
 	}
+
+	info.Messages = append(info.Messages, messageDetails)
 
 	userMessages.Set(uHash, info, cooldown)
 
@@ -124,7 +125,7 @@ func timeoutUser(e *events.GuildMessageCreate, guildSettings *model.GuildSetting
 	}
 
 	for _, m := range removableMessages {
-		err := e.Client().Rest.DeleteMessage(m.ChannelID, m.MessageID)
+		err := e.Client().Rest.DeleteMessage(m.ChannelID, m.MessageID, rest.WithReason("Message deleted due to anti-spam settings."))
 		if err != nil {
 			slog.Error(
 				"Failed to delete message.", "err", err, "guild", e.GuildID, "channel", m.ChannelID, "message",


### PR DESCRIPTION
Replaces the plain-text moderator notification with a structured V2 message using container and section components, showing each spam message with its channel and user mention.