### PR TITLE
feat(audit): add fallback Entry for cold-cache member update events

### DIFF
--- a/audit/pending.go
+++ b/audit/pending.go
@@ -38,6 +38,7 @@
 package audit
 
 import (
+	"log/slog"
 	"sync"
 	"time"
 
@@ -148,6 +149,14 @@ type pendingEnrichment struct {
 	timer           *time.Timer
 	expired         bool
 	mu              sync.Mutex
+	// fallback, if non-nil, is committed verbatim when the enrichment
+	// expires without consuming a pending entry. Used for events the
+	// native side can fully reconstruct on its own — moderator-driven
+	// member nick/role/timeout changes specifically, where the gateway
+	// listener bails on cold cache (no old state to diff against) and
+	// no pending entry ever arrives. On warm cache the gateway entry
+	// matches first and the fallback is discarded.
+	fallback *Entry
 }
 
 // pendingBuffer holds entries waiting for native-audit enrichment and
@@ -316,6 +325,69 @@ func TryEnrich(
 	match MatchMode,
 	maxMatches int,
 ) int {
+	return tryEnrich(guildID, eventType, targetID, requiredDetails, actorID, actorKind, actorUsername, reason, match, maxMatches, nil)
+}
+
+// TryEnrichWithFallback is TryEnrich plus a fallback Entry that is
+// committed if the enrichment is buffered and its TTL elapses without
+// consuming a pending entry. Use this for events the native audit log
+// fully describes on its own — moderator-driven member changes (nick,
+// role, timeout) where a cold gateway cache makes our own listener bail
+// and no pending entry will arrive.
+//
+// On warm cache the gateway pending entry matches first; the enrichment
+// is consumed inline and the fallback is dropped without being written.
+// On cold cache the buffered enrichment times out, expireEnrichment
+// commits the fallback, and the event is preserved with full attribution
+// from Discord's native side.
+//
+// The fallback path is only well-defined for MatchFirst — MatchAll can
+// serve N inline matches AND then commit the fallback at TTL, producing
+// a duplicate. If a non-MatchFirst match mode is passed with a non-nil
+// fallback, the fallback is dropped with a warning and the call falls
+// back to plain TryEnrich semantics.
+//
+// shouldLog is rechecked at fallback-commit time (the toggle could flip
+// between TryEnrich and TTL expiry), so a guild that disables audit
+// logging mid-window won't receive backdoor rows.
+func TryEnrichWithFallback(
+	guildID snowflake.ID,
+	eventType EventType,
+	targetID *snowflake.ID,
+	requiredDetails map[string]string,
+	actorID *snowflake.ID,
+	actorKind ActorKind,
+	actorUsername string,
+	reason string,
+	match MatchMode,
+	maxMatches int,
+	fallback Entry,
+) int {
+	return tryEnrich(guildID, eventType, targetID, requiredDetails, actorID, actorKind, actorUsername, reason, match, maxMatches, &fallback)
+}
+
+func tryEnrich(
+	guildID snowflake.ID,
+	eventType EventType,
+	targetID *snowflake.ID,
+	requiredDetails map[string]string,
+	actorID *snowflake.ID,
+	actorKind ActorKind,
+	actorUsername string,
+	reason string,
+	match MatchMode,
+	maxMatches int,
+	fallback *Entry,
+) int {
+	// MatchAll + fallback is unsupported: the enrichment can serve N
+	// inline matches AND then commit the fallback at TTL, producing a
+	// duplicate. Drop the fallback rather than introduce a quietly-wrong
+	// row. Only MatchFirst guarantees "inline match OR fallback, not both".
+	if fallback != nil && match != MatchFirst {
+		slog.Warn("audit: dropping fallback paired with non-MatchFirst — unsupported combination",
+			"guild_id", guildID, "event_type", eventType)
+		fallback = nil
+	}
 	// Clamp negative caps to "unlimited" so misbehaving callers can't
 	// accidentally disable the buffered-enrichment path with -1.
 	if maxMatches < 0 {
@@ -388,6 +460,7 @@ func TryEnrich(
 			reason:          reason,
 			match:           match,
 			remaining:       bufferRemaining,
+			fallback:        fallback,
 		}
 		en.timer = time.AfterFunc(pendingTTL, func() {
 			expireEnrichment(key, en)
@@ -458,9 +531,21 @@ func FlushPending() {
 	for _, list := range allEnrichments {
 		for _, en := range list {
 			en.mu.Lock()
+			alreadyExpired := en.expired
 			en.expired = true
 			en.timer.Stop()
+			fallback := en.fallback
 			en.mu.Unlock()
+			// On shutdown, preserve cold-cache fallbacks the same way
+			// expireEnrichment would have at TTL. Skip if the enrichment
+			// already expired (its expire path either committed the
+			// fallback already or there was no fallback to commit).
+			// shouldLog gate mirrors expireEnrichment's: a guild may
+			// have disabled audit logging between buffer time and the
+			// flush, and the fallback bypasses LogPending / Log.
+			if !alreadyExpired && fallback != nil && shouldLog(fallback.GuildID) {
+				commit(*fallback)
+			}
 		}
 	}
 }
@@ -507,10 +592,14 @@ func flushOne(pe *pendingEntry) {
 }
 
 // expireEnrichment removes an unconsumed enrichment from the buffer when
-// its TTL fires. No commit happens — an unmatched enrichment is just an
-// audit log entry Discord told us about that we never saw via gateway,
-// which we deliberately do not record (we only persist gateway-witnessed
-// events to keep one row per real-world action).
+// its TTL fires. By default no commit happens — an unmatched enrichment
+// is just a native audit log entry we never saw via gateway, which we
+// deliberately do not record (one row per real-world action).
+//
+// The exception is when the enrichment carries a fallback Entry (set by
+// TryEnrichWithFallback). That's the cold-cache moderator-action case:
+// the native side has full details and the gateway will never file a
+// pending entry, so we commit the fallback to preserve the event.
 func expireEnrichment(key pendingKey, en *pendingEnrichment) {
 	en.mu.Lock()
 	if en.expired {
@@ -518,12 +607,15 @@ func expireEnrichment(key pendingKey, en *pendingEnrichment) {
 		return
 	}
 	en.expired = true
+	fallback := en.fallback
 	en.mu.Unlock()
 
+	var stillInBuffer bool
 	pendingBuffer.mu.Lock()
 	list := pendingBuffer.enrichments[key]
 	for i, e := range list {
 		if e == en {
+			stillInBuffer = true
 			pendingBuffer.enrichments[key] = append(list[:i], list[i+1:]...)
 			if len(pendingBuffer.enrichments[key]) == 0 {
 				delete(pendingBuffer.enrichments, key)
@@ -532,6 +624,22 @@ func expireEnrichment(key pendingKey, en *pendingEnrichment) {
 		}
 	}
 	pendingBuffer.mu.Unlock()
+
+	// Only commit the fallback if this path was the one that removed the
+	// enrichment from the buffer. LogPending's findAndRemoveEnrichmentLocked
+	// runs under buffer.mu and may have already consumed the enrichment for
+	// a late-arriving gateway entry between en.mu being released and us
+	// re-acquiring buffer.mu — in that case the gateway side will commit
+	// the enriched row and the fallback would be a duplicate.
+	//
+	// Re-check shouldLog here even though TryEnrich was already called:
+	// the fallback commit bypasses LogPending / Log (which gate on the
+	// toggle), and a guild could have disabled audit logging between
+	// buffer time and TTL expiry. Without this gate, disabled guilds
+	// would receive backdoor rows.
+	if stillInBuffer && fallback != nil && shouldLog(fallback.GuildID) {
+		commit(*fallback)
+	}
 }
 
 // matchesTarget returns true when filterTarget matches entryTarget. nil

--- a/audit/pending.go
+++ b/audit/pending.go
@@ -796,9 +796,10 @@ func cloneEntry(e Entry) Entry {
 // booleans) are immutable from Go's perspective and copied via assignment;
 // nested maps and slices are recursively cloned so the result shares no
 // mutable storage with the input. Unrecognised composite types fall through
-// to a shallow assignment — callers using exotic value shapes must clone
-// them themselves; current audit listeners only emit string / float /
-// map / slice combinations.
+// to a shallow assignment — callers using exotic mutable value shapes must
+// clone them themselves. Current audit listeners also emit shallow-copied
+// pointer values such as *time.Time (for example timeout_until), in addition
+// to string / float / map / slice combinations.
 func cloneDetails(d map[string]any) map[string]any {
 	if d == nil {
 		return nil

--- a/audit/pending.go
+++ b/audit/pending.go
@@ -157,6 +157,12 @@ type pendingEnrichment struct {
 	// no pending entry ever arrives. On warm cache the gateway entry
 	// matches first and the fallback is discarded.
 	fallback *Entry
+	// fallbackCommitted is set under en.mu by whichever path (TTL expiry
+	// or FlushPending) succeeds in committing the fallback. Both paths
+	// do check-and-set under the same lock so they can't double-commit
+	// if a shutdown coincides with TTL: one wins the claim and calls
+	// Log, the other observes fallbackCommitted == true and skips.
+	fallbackCommitted bool
 }
 
 // pendingBuffer holds entries waiting for native-audit enrichment and
@@ -347,9 +353,12 @@ func TryEnrich(
 // fallback, the fallback is dropped with a warning and the call falls
 // back to plain TryEnrich semantics.
 //
-// shouldLog is rechecked at fallback-commit time (the toggle could flip
-// between TryEnrich and TTL expiry), so a guild that disables audit
-// logging mid-window won't receive backdoor rows.
+// The fallback commit is routed through Log (not the package-internal
+// commit) so it inherits Category derivation, the empty-Category warning
+// + drop, and the shouldLog re-check — meaning a guild that disables
+// audit logging between TryEnrich and TTL expiry won't get backdoor rows
+// and a caller that forgets to set Category won't silently produce a
+// broken row.
 func TryEnrichWithFallback(
 	guildID snowflake.ID,
 	eventType EventType,
@@ -530,21 +539,22 @@ func FlushPending() {
 	}
 	for _, list := range allEnrichments {
 		for _, en := range list {
+			// Check-and-set fallbackCommitted under en.mu — see the
+			// comment on expireEnrichment for the race we're defending
+			// against. en.expired is set unconditionally so any in-flight
+			// timer callback bails on entry rather than doing redundant
+			// buffer work.
 			en.mu.Lock()
-			alreadyExpired := en.expired
 			en.expired = true
 			en.timer.Stop()
 			fallback := en.fallback
+			won := fallback != nil && !en.fallbackCommitted
+			if won {
+				en.fallbackCommitted = true
+			}
 			en.mu.Unlock()
-			// On shutdown, preserve cold-cache fallbacks the same way
-			// expireEnrichment would have at TTL. Skip if the enrichment
-			// already expired (its expire path either committed the
-			// fallback already or there was no fallback to commit).
-			// shouldLog gate mirrors expireEnrichment's: a guild may
-			// have disabled audit logging between buffer time and the
-			// flush, and the fallback bypasses LogPending / Log.
-			if !alreadyExpired && fallback != nil && shouldLog(fallback.GuildID) {
-				commit(*fallback)
+			if won {
+				Log(*fallback)
 			}
 		}
 	}
@@ -600,6 +610,14 @@ func flushOne(pe *pendingEntry) {
 // TryEnrichWithFallback). That's the cold-cache moderator-action case:
 // the native side has full details and the gateway will never file a
 // pending entry, so we commit the fallback to preserve the event.
+//
+// Race with FlushPending: if a shutdown swaps the buffer between us
+// releasing en.mu and re-acquiring buffer.mu, our stillInBuffer check
+// returns false (FlushPending emptied the map) and FlushPending sees the
+// enrichment in its swapped-out list. Both paths could be tempted to
+// commit — or worse, both could skip. The check-and-set on
+// en.fallbackCommitted under en.mu resolves it: whichever path claims
+// the flag first commits, the other observes the flag and skips.
 func expireEnrichment(key pendingKey, en *pendingEnrichment) {
 	en.mu.Lock()
 	if en.expired {
@@ -625,20 +643,26 @@ func expireEnrichment(key pendingKey, en *pendingEnrichment) {
 	}
 	pendingBuffer.mu.Unlock()
 
-	// Only commit the fallback if this path was the one that removed the
-	// enrichment from the buffer. LogPending's findAndRemoveEnrichmentLocked
-	// runs under buffer.mu and may have already consumed the enrichment for
-	// a late-arriving gateway entry between en.mu being released and us
-	// re-acquiring buffer.mu — in that case the gateway side will commit
-	// the enriched row and the fallback would be a duplicate.
-	//
-	// Re-check shouldLog here even though TryEnrich was already called:
-	// the fallback commit bypasses LogPending / Log (which gate on the
-	// toggle), and a guild could have disabled audit logging between
-	// buffer time and TTL expiry. Without this gate, disabled guilds
-	// would receive backdoor rows.
-	if stillInBuffer && fallback != nil && shouldLog(fallback.GuildID) {
-		commit(*fallback)
+	// stillInBuffer false means either LogPending consumed (gateway took
+	// the row) or FlushPending swapped the buffer mid-flight (FlushPending
+	// will commit the fallback). Either way, leave the commit to the
+	// other path.
+	if !stillInBuffer || fallback == nil {
+		return
+	}
+
+	// Claim the right to commit. Route through Log so the fallback
+	// inherits Category derivation, the empty-Category drop-with-warning,
+	// and a re-check of shouldLog (the toggle could flip between
+	// TryEnrich and TTL expiry).
+	en.mu.Lock()
+	won := !en.fallbackCommitted
+	if won {
+		en.fallbackCommitted = true
+	}
+	en.mu.Unlock()
+	if won {
+		Log(*fallback)
 	}
 }
 

--- a/audit/pending.go
+++ b/audit/pending.go
@@ -197,6 +197,12 @@ func LogPending(entry Entry, enrichable []EnrichField) {
 		return
 	}
 
+	// Decouple from the caller's storage. The entry sits in the buffer
+	// until commit; without cloning, a caller that recycles its Details
+	// map (or mutates the snowflake pointers' targets) would race with
+	// the TTL goroutine reading the stored copy.
+	entry = cloneEntry(entry)
+
 	allowed := make(map[EnrichField]bool, len(enrichable))
 	for _, f := range enrichable {
 		allowed[f] = true
@@ -359,6 +365,17 @@ func TryEnrich(
 // audit logging between TryEnrich and TTL expiry won't get backdoor rows
 // and a caller that forgets to set Category won't silently produce a
 // broken row.
+//
+// Ownership: the fallback Entry is deep-cloned on entry, so the caller
+// may mutate (or recycle) the Details map and the snowflake-pointer
+// targets after this returns without affecting the buffered copy or
+// racing the TTL goroutine.
+//
+// Identity normalization: the fallback's GuildID / EventType / TargetID
+// are overwritten with the explicit guildID / eventType / targetID args
+// before buffering. Mismatch is logged at warn level so caller bugs are
+// visible, but the row that eventually gets written is internally
+// consistent with how it would have been keyed.
 func TryEnrichWithFallback(
 	guildID snowflake.ID,
 	eventType EventType,
@@ -396,6 +413,28 @@ func tryEnrich(
 		slog.Warn("audit: dropping fallback paired with non-MatchFirst — unsupported combination",
 			"guild_id", guildID, "event_type", eventType)
 		fallback = nil
+	}
+	if fallback != nil {
+		// Defend against caller misuse: the fallback's identity fields
+		// must match the explicit match-key args, otherwise we'd commit
+		// a row keyed differently than the buffered enrichment we're
+		// supposedly replacing. Warn loudly so the bug is visible, then
+		// normalize so the row that gets written is at least internally
+		// consistent. The clone also decouples the stored fallback from
+		// the caller's storage — TTL expiry can fire on another goroutine
+		// 1.5s later, and we don't want to race the caller's Details map.
+		if fallback.GuildID != guildID ||
+			fallback.EventType != eventType ||
+			!snowflakePtrEqual(fallback.TargetID, targetID) {
+			slog.Warn("audit: fallback identity fields don't match explicit args — normalizing",
+				"explicit_guild", guildID, "fallback_guild", fallback.GuildID,
+				"explicit_event", eventType, "fallback_event", fallback.EventType)
+		}
+		cloned := cloneEntry(*fallback)
+		cloned.GuildID = guildID
+		cloned.EventType = eventType
+		cloned.TargetID = copySnowflake(targetID)
+		fallback = &cloned
 	}
 	// Clamp negative caps to "unlimited" so misbehaving callers can't
 	// accidentally disable the buffered-enrichment path with -1.
@@ -721,6 +760,15 @@ func copySnowflake(id *snowflake.ID) *snowflake.ID {
 	return &v
 }
 
+// snowflakePtrEqual treats nil pointers as equal to other nils and
+// dereferences non-nil pointers to compare the underlying IDs.
+func snowflakePtrEqual(a, b *snowflake.ID) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
 func copyStringMap(m map[string]string) map[string]string {
 	if len(m) == 0 {
 		return nil
@@ -730,4 +778,59 @@ func copyStringMap(m map[string]string) map[string]string {
 		out[k] = v
 	}
 	return out
+}
+
+// cloneEntry returns an Entry safe to retain across goroutine boundaries.
+// The caller's Details map and the snowflake pointers are not aliased by
+// the returned value, so the caller can mutate (or recycle) the original
+// after the call without affecting what eventually gets committed — and
+// without racing the TTL goroutine that reads the stored copy.
+func cloneEntry(e Entry) Entry {
+	e.ActorID = copySnowflake(e.ActorID)
+	e.TargetID = copySnowflake(e.TargetID)
+	e.Details = cloneDetails(e.Details)
+	return e
+}
+
+// cloneDetails deep-copies a Details map. Scalar values (strings, numbers,
+// booleans) are immutable from Go's perspective and copied via assignment;
+// nested maps and slices are recursively cloned so the result shares no
+// mutable storage with the input. Unrecognised composite types fall through
+// to a shallow assignment — callers using exotic value shapes must clone
+// them themselves; current audit listeners only emit string / float /
+// map / slice combinations.
+func cloneDetails(d map[string]any) map[string]any {
+	if d == nil {
+		return nil
+	}
+	out := make(map[string]any, len(d))
+	for k, v := range d {
+		out[k] = cloneDetailValue(v)
+	}
+	return out
+}
+
+func cloneDetailValue(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		return cloneDetails(x)
+	case []any:
+		out := make([]any, len(x))
+		for i, item := range x {
+			out[i] = cloneDetailValue(item)
+		}
+		return out
+	case []map[string]any:
+		out := make([]map[string]any, len(x))
+		for i, m := range x {
+			out[i] = cloneDetails(m)
+		}
+		return out
+	case []string:
+		out := make([]string, len(x))
+		copy(out, x)
+		return out
+	}
+	// Scalars and unknown types: shallow assignment.
+	return v
 }

--- a/audit/pending_test.go
+++ b/audit/pending_test.go
@@ -65,6 +65,32 @@ func countRows(t *testing.T, guildID snowflake.ID) int64 {
 	return count
 }
 
+// waitForRows polls until countRows(guildID) == want or a timeout
+// elapses. Replaces fixed-duration "sleep past TTL + padding" patterns:
+// on success the test continues as soon as the commit lands (typically a
+// few ms after pendingTTL fires) instead of always paying the full
+// padding. Failure path still has a generous upper bound so a slow CI
+// runner doesn't flake.
+func waitForRows(t *testing.T, guildID snowflake.ID, want int64) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return countRows(t, guildID) == want
+	}, pendingTTL*8, pendingTTL/5,
+		"expected %d row(s) for guild %d", want, guildID)
+}
+
+// assertRowsStayAt asserts countRows(guildID) stays at want for at least
+// pendingTTL*2 — long enough to be confident no late commit will arrive.
+// Use for "must NOT commit" scenarios (disabled guild, dropped fallback)
+// or to verify no duplicate after an inline commit.
+func assertRowsStayAt(t *testing.T, guildID snowflake.ID, want int64) {
+	t.Helper()
+	require.Never(t, func() bool {
+		return countRows(t, guildID) != want
+	}, pendingTTL*2, pendingTTL/2,
+		"row count for guild %d must stay at %d", guildID, want)
+}
+
 func TestLogPending_FlushesAfterTTL(t *testing.T) {
 	setupTestDB(t)
 	guildID := snowflake.ID(1001)
@@ -84,8 +110,7 @@ func TestLogPending_FlushesAfterTTL(t *testing.T) {
 	// Pre-TTL: the row hasn't been written yet.
 	assert.EqualValues(t, 0, countRows(t, guildID))
 
-	time.Sleep(pendingTTL + 200*time.Millisecond)
-	assert.EqualValues(t, 1, countRows(t, guildID), "row should have been committed after TTL")
+	waitForRows(t, guildID, 1)
 }
 
 func TestTryEnrich_AttachesActorAndCommits(t *testing.T) {
@@ -270,8 +295,7 @@ func TestTryEnrichWithFallback_CommitsOnTTLExpiry(t *testing.T) {
 	// Pre-TTL: nothing committed yet.
 	assert.EqualValues(t, 0, countRows(t, guildID))
 
-	time.Sleep(pendingTTL + 200*time.Millisecond)
-	assert.EqualValues(t, 1, countRows(t, guildID), "fallback should commit on TTL expiry")
+	waitForRows(t, guildID, 1)
 
 	var row model.AuditLogEntry
 	require.NoError(t, model.DB.Where("guild_id = ?", guildID).First(&row).Error)
@@ -326,8 +350,7 @@ func TestTryEnrichWithFallback_GatewayWinsNoDuplicate(t *testing.T) {
 
 	// Past TTL: the enrichment's timer fires, but since the buffer entry
 	// was already consumed by LogPending the fallback path must skip.
-	time.Sleep(pendingTTL + 200*time.Millisecond)
-	assert.EqualValues(t, 1, countRows(t, guildID), "fallback must not duplicate after gateway already enriched")
+	assertRowsStayAt(t, guildID, 1)
 }
 
 // Disabled guilds must not receive backdoor rows via the fallback path.
@@ -359,10 +382,7 @@ func TestTryEnrichWithFallback_DisabledGuildDropsFallback(t *testing.T) {
 	TryEnrichWithFallback(guildID, EventMemberNickChange, &target, nil,
 		&moderator, ActorUser, "modUser", "", MatchFirst, 0, fallback)
 
-	time.Sleep(pendingTTL + 200*time.Millisecond)
-
-	assert.EqualValues(t, 0, countRows(t, guildID),
-		"disabled guild must not get fallback row written")
+	assertRowsStayAt(t, guildID, 0)
 }
 
 // The fallback's Category must persist to the row — without it, retention
@@ -390,7 +410,7 @@ func TestTryEnrichWithFallback_PersistsCategory(t *testing.T) {
 
 	TryEnrichWithFallback(guildID, EventMemberNickChange, &target, nil,
 		&moderator, ActorUser, "modUser", "", MatchFirst, 0, fallback)
-	time.Sleep(pendingTTL + 200*time.Millisecond)
+	waitForRows(t, guildID, 1)
 
 	var row model.AuditLogEntry
 	require.NoError(t, model.DB.Where("guild_id = ?", guildID).First(&row).Error)
@@ -595,7 +615,7 @@ func TestTryEnrichWithFallback_ClonesCallerStorage(t *testing.T) {
 	moderator = snowflake.ID(99999)
 	target = snowflake.ID(99998)
 
-	time.Sleep(pendingTTL + 200*time.Millisecond)
+	waitForRows(t, guildID, 1)
 
 	var row model.AuditLogEntry
 	require.NoError(t, model.DB.Where("guild_id = ?", guildID).First(&row).Error)
@@ -639,10 +659,9 @@ func TestTryEnrichWithFallback_NormalizesIdentity(t *testing.T) {
 
 	TryEnrichWithFallback(guildID, EventMemberNickChange, &target, nil,
 		&moderator, ActorUser, "modUser", "", MatchFirst, 0, fallback)
-	time.Sleep(pendingTTL + 200*time.Millisecond)
 
 	// Row should land under the explicit guild, not the fallback's wrong one.
-	assert.EqualValues(t, 1, countRows(t, guildID))
+	waitForRows(t, guildID, 1)
 	assert.EqualValues(t, 0, countRows(t, wrongGuild))
 
 	var row model.AuditLogEntry
@@ -677,10 +696,8 @@ func TestTryEnrichWithFallback_MatchAllDropsFallback(t *testing.T) {
 
 	TryEnrichWithFallback(guildID, EventMessageDelete, &target, nil,
 		&moderator, ActorUser, "modUser", "", MatchAll, 0, fallback)
-	time.Sleep(pendingTTL + 200*time.Millisecond)
 
-	assert.EqualValues(t, 0, countRows(t, guildID),
-		"MatchAll + fallback must drop the fallback (would otherwise duplicate)")
+	assertRowsStayAt(t, guildID, 0)
 }
 
 // MatchFirst enrichments are one-shot: once a matching gateway entry has
@@ -725,9 +742,7 @@ func TestTryEnrich_MatchFirstDoesNotBleedIntoNextEntry(t *testing.T) {
 	}, []EnrichField{EnrichActor, EnrichReason})
 
 	// Wait past TTL so the second pending entry flushes.
-	time.Sleep(pendingTTL + 200*time.Millisecond)
-
-	assert.EqualValues(t, 2, countRows(t, guildID))
+	waitForRows(t, guildID, 2)
 
 	var rows []model.AuditLogEntry
 	require.NoError(t, model.DB.Where("guild_id = ?", guildID).Order("created_at ASC").Find(&rows).Error)
@@ -807,8 +822,7 @@ func TestTryEnrich_MessageDelete_DetailsScope(t *testing.T) {
 	assert.Equal(t, 1, enriched, "only the mod-deleted message should be enriched")
 
 	// Let the unrelated self-delete flush unenriched.
-	time.Sleep(pendingTTL + 200*time.Millisecond)
-	assert.EqualValues(t, 2, countRows(t, guildID))
+	waitForRows(t, guildID, 2)
 
 	var rows []model.AuditLogEntry
 	require.NoError(t, model.DB.Where("guild_id = ?", guildID).Order("target_id ASC").Find(&rows).Error)
@@ -885,8 +899,7 @@ func TestTryEnrich_MessageDelete_NativeFirst_DetailsScope(t *testing.T) {
 	}, []EnrichField{EnrichActor, EnrichReason})
 
 	// Let the bystander entry flush unenriched.
-	time.Sleep(pendingTTL + 200*time.Millisecond)
-	assert.EqualValues(t, 2, countRows(t, guildID))
+	waitForRows(t, guildID, 2)
 
 	var rows []model.AuditLogEntry
 	require.NoError(t, model.DB.Where("guild_id = ?", guildID).Order("target_id ASC").Find(&rows).Error)
@@ -951,8 +964,7 @@ func TestTryEnrich_MatchAll_CountCap(t *testing.T) {
 	makePending(8402)
 	makePending(8403)
 
-	time.Sleep(pendingTTL + 200*time.Millisecond)
-	assert.EqualValues(t, 3, countRows(t, guildID))
+	waitForRows(t, guildID, 3)
 
 	var rows []model.AuditLogEntry
 	require.NoError(t, model.DB.Where("guild_id = ?", guildID).Order("target_id ASC").Find(&rows).Error)
@@ -1016,8 +1028,7 @@ func TestTryEnrich_MatchAll_CountCap_InlinePlusBuffered(t *testing.T) {
 	makePending(8803)
 	makePending(8804)
 
-	time.Sleep(pendingTTL + 200*time.Millisecond)
-	assert.EqualValues(t, 4, countRows(t, guildID))
+	waitForRows(t, guildID, 4)
 
 	var rows []model.AuditLogEntry
 	require.NoError(t, model.DB.Where("guild_id = ?", guildID).Order("target_id ASC").Find(&rows).Error)
@@ -1072,8 +1083,7 @@ func TestTryEnrich_DetailsMatch_RequiresAllKeys(t *testing.T) {
 		&moderator, ActorUser, "modUser", "spam", MatchFirst, 0)
 	assert.Equal(t, 0, enriched, "missing author_id must not match")
 
-	time.Sleep(pendingTTL + 200*time.Millisecond)
-	assert.EqualValues(t, 1, countRows(t, guildID))
+	waitForRows(t, guildID, 1)
 
 	var row model.AuditLogEntry
 	require.NoError(t, model.DB.Where("guild_id = ?", guildID).First(&row).Error)

--- a/audit/pending_test.go
+++ b/audit/pending_test.go
@@ -233,6 +233,200 @@ func TestTryEnrich_NativeBeforeGateway(t *testing.T) {
 	assert.Equal(t, "timeout", row.Reason)
 }
 
+// TryEnrichWithFallback's cold-cache path: native enrichment arrives,
+// no pending entry is ever filed (the gateway listener bailed because
+// the member wasn't cached), TTL expires — the fallback Entry must be
+// committed so the moderator-driven event isn't silently lost.
+func TestTryEnrichWithFallback_CommitsOnTTLExpiry(t *testing.T) {
+	setupTestDB(t)
+	guildID := snowflake.ID(1300)
+	guildEnabled(t, guildID)
+
+	target := snowflake.ID(13001)
+	moderator := snowflake.ID(13002)
+
+	fallback := Entry{
+		GuildID:    guildID,
+		EventType:  EventMemberNickChange,
+		Category:   CategoryMember,
+		ActorID:    &moderator,
+		ActorKind:  ActorUser,
+		TargetID:   &target,
+		TargetKind: TargetUser,
+		Source:     SourceGateway,
+		Reason:     "policy",
+		Details: map[string]any{
+			"nick_before":     "old",
+			"nick_after":      "new",
+			"actor_username":  "modUser",
+			"target_username": "targetUser",
+		},
+	}
+
+	enriched := TryEnrichWithFallback(guildID, EventMemberNickChange, &target, nil,
+		&moderator, ActorUser, "modUser", "policy", MatchFirst, 0, fallback)
+	assert.Equal(t, 0, enriched, "no pending entries — buffered with fallback")
+
+	// Pre-TTL: nothing committed yet.
+	assert.EqualValues(t, 0, countRows(t, guildID))
+
+	time.Sleep(pendingTTL + 200*time.Millisecond)
+	assert.EqualValues(t, 1, countRows(t, guildID), "fallback should commit on TTL expiry")
+
+	var row model.AuditLogEntry
+	require.NoError(t, model.DB.Where("guild_id = ?", guildID).First(&row).Error)
+	require.NotNil(t, row.ActorID)
+	assert.Equal(t, moderator, *row.ActorID)
+	assert.Equal(t, "policy", row.Reason)
+	assert.Contains(t, row.Details, "nick_after")
+}
+
+// TryEnrichWithFallback's warm-cache path: the gateway pending entry
+// arrives within the TTL window, the buffered enrichment is consumed
+// inline, the fallback must NOT also commit (would produce a duplicate).
+func TestTryEnrichWithFallback_GatewayWinsNoDuplicate(t *testing.T) {
+	setupTestDB(t)
+	guildID := snowflake.ID(1301)
+	guildEnabled(t, guildID)
+
+	target := snowflake.ID(13011)
+	moderator := snowflake.ID(13012)
+
+	fallback := Entry{
+		GuildID:    guildID,
+		EventType:  EventMemberNickChange,
+		Category:   CategoryMember,
+		ActorID:    &moderator,
+		ActorKind:  ActorUser,
+		TargetID:   &target,
+		TargetKind: TargetUser,
+		Source:     SourceGateway,
+		Reason:     "policy",
+		Details:    map[string]any{"nick_before": "old", "nick_after": "new"},
+	}
+
+	// Native arrives first, buffered with fallback.
+	TryEnrichWithFallback(guildID, EventMemberNickChange, &target, nil,
+		&moderator, ActorUser, "modUser", "policy", MatchFirst, 0, fallback)
+
+	// Gateway arrives within TTL → consumes the buffered enrichment.
+	LogPending(Entry{
+		GuildID:    guildID,
+		EventType:  EventMemberNickChange,
+		Category:   CategoryMember,
+		ActorKind:  ActorUnknown,
+		TargetID:   &target,
+		TargetKind: TargetUser,
+		Source:     SourceGateway,
+		Details:    map[string]any{"nick_before": "old", "nick_after": "new"},
+	}, []EnrichField{EnrichActor, EnrichReason})
+
+	// Gateway entry committed immediately on enrichment.
+	assert.EqualValues(t, 1, countRows(t, guildID))
+
+	// Past TTL: the enrichment's timer fires, but since the buffer entry
+	// was already consumed by LogPending the fallback path must skip.
+	time.Sleep(pendingTTL + 200*time.Millisecond)
+	assert.EqualValues(t, 1, countRows(t, guildID), "fallback must not duplicate after gateway already enriched")
+}
+
+// Disabled guilds must not receive backdoor rows via the fallback path.
+// The native enrichment listener calls TryEnrichWithFallback for every
+// moderator member-action regardless of the per-guild toggle; the
+// shouldLog re-check inside expireEnrichment must drop the fallback
+// when the guild has audit logging off.
+func TestTryEnrichWithFallback_DisabledGuildDropsFallback(t *testing.T) {
+	setupTestDB(t)
+	guildID := snowflake.ID(1302)
+	// Deliberately do NOT call guildEnabled — the guild_settings row
+	// stays at AuditLogEnabled=false (default).
+
+	target := snowflake.ID(13021)
+	moderator := snowflake.ID(13022)
+
+	fallback := Entry{
+		GuildID:    guildID,
+		Category:   CategoryMember,
+		EventType:  EventMemberNickChange,
+		ActorID:    &moderator,
+		ActorKind:  ActorUser,
+		TargetID:   &target,
+		TargetKind: TargetUser,
+		Source:     SourceGateway,
+		Details:    map[string]any{"nick_before": "old", "nick_after": "new"},
+	}
+
+	TryEnrichWithFallback(guildID, EventMemberNickChange, &target, nil,
+		&moderator, ActorUser, "modUser", "", MatchFirst, 0, fallback)
+
+	time.Sleep(pendingTTL + 200*time.Millisecond)
+
+	assert.EqualValues(t, 0, countRows(t, guildID),
+		"disabled guild must not get fallback row written")
+}
+
+// The fallback's Category must persist to the row — without it, retention
+// pruning (which filters on exact category match) silently leaks
+// fallback rows forever, and the viewer's category filter misses them.
+func TestTryEnrichWithFallback_PersistsCategory(t *testing.T) {
+	setupTestDB(t)
+	guildID := snowflake.ID(1303)
+	guildEnabled(t, guildID)
+
+	target := snowflake.ID(13031)
+	moderator := snowflake.ID(13032)
+
+	fallback := Entry{
+		GuildID:    guildID,
+		Category:   CategoryMember,
+		EventType:  EventMemberNickChange,
+		ActorID:    &moderator,
+		ActorKind:  ActorUser,
+		TargetID:   &target,
+		TargetKind: TargetUser,
+		Source:     SourceGateway,
+		Details:    map[string]any{"nick_before": "old", "nick_after": "new"},
+	}
+
+	TryEnrichWithFallback(guildID, EventMemberNickChange, &target, nil,
+		&moderator, ActorUser, "modUser", "", MatchFirst, 0, fallback)
+	time.Sleep(pendingTTL + 200*time.Millisecond)
+
+	var row model.AuditLogEntry
+	require.NoError(t, model.DB.Where("guild_id = ?", guildID).First(&row).Error)
+	assert.Equal(t, string(CategoryMember), row.Category,
+		"fallback row must carry its Category — retention pruning and viewer filters depend on it")
+}
+
+// MatchAll + fallback is unsupported (would duplicate). The pairing must
+// drop the fallback rather than silently emit two rows.
+func TestTryEnrichWithFallback_MatchAllDropsFallback(t *testing.T) {
+	setupTestDB(t)
+	guildID := snowflake.ID(1304)
+	guildEnabled(t, guildID)
+
+	target := snowflake.ID(13041)
+	moderator := snowflake.ID(13042)
+
+	fallback := Entry{
+		GuildID:    guildID,
+		Category:   CategoryMessage,
+		EventType:  EventMessageDelete,
+		ActorID:    &moderator,
+		ActorKind:  ActorUser,
+		TargetID:   &target,
+		TargetKind: TargetUser,
+		Source:     SourceGateway,
+	}
+
+	TryEnrichWithFallback(guildID, EventMessageDelete, &target, nil,
+		&moderator, ActorUser, "modUser", "", MatchAll, 0, fallback)
+	time.Sleep(pendingTTL + 200*time.Millisecond)
+
+	assert.EqualValues(t, 0, countRows(t, guildID),
+		"MatchAll + fallback must drop the fallback (would otherwise duplicate)")
+}
+
 // MatchFirst enrichments are one-shot: once a matching gateway entry has
 // been enriched, the enrichment must NOT linger in the buffer to latch
 // onto the next unrelated gateway event for the same (guild, event,

--- a/audit/pending_test.go
+++ b/audit/pending_test.go
@@ -494,9 +494,18 @@ func TestTryEnrichWithFallback_FlushSkipsConsumedFallback(t *testing.T) {
 //
 // Reproduces the race deterministically by setting en.expired manually
 // before calling FlushPending (simulating expireEnrichment having
-// claimed but not yet committed).
+// claimed but not yet committed). pendingTTL is bumped to a value
+// large enough that the buffered timer cannot fire during the manual
+// setup phase even on a slow CI runner — without this the timer's
+// real expireEnrichment could fire between the TryEnrichWithFallback
+// call and the manual lookup, making the test pass for the wrong
+// reason (or fail intermittently).
 func TestTryEnrichWithFallback_ExpireFlushRace(t *testing.T) {
 	setupTestDB(t)
+	prevTTL := pendingTTL
+	pendingTTL = 30 * time.Second
+	t.Cleanup(func() { pendingTTL = prevTTL })
+
 	guildID := snowflake.ID(1307)
 	guildEnabled(t, guildID)
 
@@ -542,13 +551,107 @@ func TestTryEnrichWithFallback_ExpireFlushRace(t *testing.T) {
 	// check-and-set it commits the fallback because nobody else has yet.
 	FlushPending()
 
-	// Give any in-flight timer callback a moment to run; it should bail
-	// on en.expired without writing anything (and FlushPending stopped
-	// the timer anyway).
-	time.Sleep(pendingTTL + 100*time.Millisecond)
-
 	assert.EqualValues(t, 1, countRows(t, guildID),
 		"FlushPending must commit fallback even when expireEnrichment claimed it but didn't get to commit")
+}
+
+// The fallback Entry must be decoupled from the caller's storage:
+// mutating Details or the snowflake pointers' targets after the call
+// must not affect what eventually gets committed. Without the deep
+// clone in TryEnrichWithFallback this would both (a) corrupt the
+// stored row and (b) race the TTL goroutine reading Details for the
+// commit's JSON marshal.
+func TestTryEnrichWithFallback_ClonesCallerStorage(t *testing.T) {
+	setupTestDB(t)
+	guildID := snowflake.ID(1308)
+	guildEnabled(t, guildID)
+
+	target := snowflake.ID(13081)
+	moderator := snowflake.ID(13082)
+
+	details := map[string]any{
+		"nick_before": "original-old",
+		"nick_after":  "original-new",
+	}
+	fallback := Entry{
+		GuildID:    guildID,
+		Category:   CategoryMember,
+		EventType:  EventMemberNickChange,
+		ActorID:    &moderator,
+		ActorKind:  ActorUser,
+		TargetID:   &target,
+		TargetKind: TargetUser,
+		Source:     SourceGateway,
+		Details:    details,
+	}
+
+	TryEnrichWithFallback(guildID, EventMemberNickChange, &target, nil,
+		&moderator, ActorUser, "modUser", "", MatchFirst, 0, fallback)
+
+	// Mutate everything the caller still holds references to.
+	details["nick_before"] = "MUTATED"
+	details["nick_after"] = "MUTATED"
+	delete(details, "nick_before")
+	moderator = snowflake.ID(99999)
+	target = snowflake.ID(99998)
+
+	time.Sleep(pendingTTL + 200*time.Millisecond)
+
+	var row model.AuditLogEntry
+	require.NoError(t, model.DB.Where("guild_id = ?", guildID).First(&row).Error)
+	assert.Contains(t, row.Details, "original-old",
+		"stored Details must reflect pre-mutation state — buffered fallback shouldn't alias caller's map")
+	assert.NotContains(t, row.Details, "MUTATED",
+		"caller's post-call mutation must not be visible in the stored row")
+	require.NotNil(t, row.ActorID)
+	assert.Equal(t, snowflake.ID(13082), *row.ActorID,
+		"stored ActorID must reflect pre-mutation value — buffered fallback shouldn't alias caller's pointer target")
+	require.NotNil(t, row.TargetID)
+	assert.Equal(t, snowflake.ID(13081), *row.TargetID)
+}
+
+// The fallback's identity fields (GuildID/EventType/TargetID) are
+// normalized to match the explicit args at the call boundary. A
+// caller that passes mismatched values shouldn't be able to write a
+// row keyed differently than the buffered enrichment claims.
+func TestTryEnrichWithFallback_NormalizesIdentity(t *testing.T) {
+	setupTestDB(t)
+	guildID := snowflake.ID(1309)
+	guildEnabled(t, guildID)
+
+	target := snowflake.ID(13091)
+	moderator := snowflake.ID(13092)
+	wrongGuild := snowflake.ID(99999)
+	wrongTarget := snowflake.ID(99998)
+
+	fallback := Entry{
+		// Wrong identity fields — should be overwritten by explicit args.
+		GuildID:    wrongGuild,
+		EventType:  EventMessageDelete,
+		TargetID:   &wrongTarget,
+		Category:   CategoryMember,
+		ActorID:    &moderator,
+		ActorKind:  ActorUser,
+		TargetKind: TargetUser,
+		Source:     SourceGateway,
+		Details:    map[string]any{"nick_after": "new"},
+	}
+
+	TryEnrichWithFallback(guildID, EventMemberNickChange, &target, nil,
+		&moderator, ActorUser, "modUser", "", MatchFirst, 0, fallback)
+	time.Sleep(pendingTTL + 200*time.Millisecond)
+
+	// Row should land under the explicit guild, not the fallback's wrong one.
+	assert.EqualValues(t, 1, countRows(t, guildID))
+	assert.EqualValues(t, 0, countRows(t, wrongGuild))
+
+	var row model.AuditLogEntry
+	require.NoError(t, model.DB.Where("guild_id = ?", guildID).First(&row).Error)
+	assert.Equal(t, string(EventMemberNickChange), row.EventType,
+		"EventType must be the explicit arg, not the fallback's stale value")
+	require.NotNil(t, row.TargetID)
+	assert.Equal(t, snowflake.ID(13091), *row.TargetID,
+		"TargetID must be the explicit arg, not the fallback's stale value")
 }
 
 // MatchAll + fallback is unsupported (would duplicate). The pairing must

--- a/audit/pending_test.go
+++ b/audit/pending_test.go
@@ -398,6 +398,159 @@ func TestTryEnrichWithFallback_PersistsCategory(t *testing.T) {
 		"fallback row must carry its Category — retention pruning and viewer filters depend on it")
 }
 
+// FlushPending must commit unconsumed fallback rows on shutdown — the
+// cold-cache event would otherwise be silently dropped if the bot exits
+// before pendingTTL fires.
+func TestTryEnrichWithFallback_FlushCommitsFallback(t *testing.T) {
+	setupTestDB(t)
+	guildID := snowflake.ID(1305)
+	guildEnabled(t, guildID)
+
+	target := snowflake.ID(13051)
+	moderator := snowflake.ID(13052)
+
+	fallback := Entry{
+		GuildID:    guildID,
+		Category:   CategoryMember,
+		EventType:  EventMemberNickChange,
+		ActorID:    &moderator,
+		ActorKind:  ActorUser,
+		TargetID:   &target,
+		TargetKind: TargetUser,
+		Source:     SourceGateway,
+		Details:    map[string]any{"nick_before": "old", "nick_after": "new"},
+	}
+
+	TryEnrichWithFallback(guildID, EventMemberNickChange, &target, nil,
+		&moderator, ActorUser, "modUser", "", MatchFirst, 0, fallback)
+
+	// Pre-TTL: nothing committed yet — the enrichment is sitting in the
+	// buffer waiting for a gateway entry that will never come.
+	assert.EqualValues(t, 0, countRows(t, guildID))
+
+	// Bot shutdown mid-window.
+	FlushPending()
+
+	assert.EqualValues(t, 1, countRows(t, guildID),
+		"FlushPending must commit unconsumed fallback so cold-cache event isn't lost on shutdown")
+}
+
+// FlushPending must NOT commit a fallback whose enrichment was already
+// consumed by an inline gateway entry — that row was committed by the
+// gateway path and committing the fallback too would duplicate.
+func TestTryEnrichWithFallback_FlushSkipsConsumedFallback(t *testing.T) {
+	setupTestDB(t)
+	guildID := snowflake.ID(1306)
+	guildEnabled(t, guildID)
+
+	target := snowflake.ID(13061)
+	moderator := snowflake.ID(13062)
+
+	fallback := Entry{
+		GuildID:    guildID,
+		Category:   CategoryMember,
+		EventType:  EventMemberNickChange,
+		ActorID:    &moderator,
+		ActorKind:  ActorUser,
+		TargetID:   &target,
+		TargetKind: TargetUser,
+		Source:     SourceGateway,
+		Details:    map[string]any{"nick_before": "old", "nick_after": "new"},
+	}
+
+	// Native arrives first → buffered with fallback.
+	TryEnrichWithFallback(guildID, EventMemberNickChange, &target, nil,
+		&moderator, ActorUser, "modUser", "", MatchFirst, 0, fallback)
+	// Gateway arrives → consumes the enrichment, commits the row.
+	LogPending(Entry{
+		GuildID:    guildID,
+		EventType:  EventMemberNickChange,
+		Category:   CategoryMember,
+		ActorKind:  ActorUnknown,
+		TargetID:   &target,
+		TargetKind: TargetUser,
+		Source:     SourceGateway,
+		Details:    map[string]any{"nick_before": "old", "nick_after": "new"},
+	}, []EnrichField{EnrichActor, EnrichReason})
+
+	assert.EqualValues(t, 1, countRows(t, guildID))
+
+	// Now shutdown. The buffered enrichment was already removed by
+	// LogPending, but the timer may still be alive — FlushPending must
+	// not double-commit.
+	FlushPending()
+
+	assert.EqualValues(t, 1, countRows(t, guildID),
+		"FlushPending must not duplicate a fallback whose enrichment was already consumed")
+}
+
+// Exercises the race between expireEnrichment and FlushPending: if
+// expireEnrichment has set en.expired = true but FlushPending swaps the
+// buffer before expireEnrichment can re-acquire buffer.mu, expireEnrichment
+// sees stillInBuffer = false and skips. Without the fallbackCommitted
+// check-and-set, FlushPending would also see expired = true and skip,
+// silently dropping the row. The check-and-set guarantees exactly one
+// path commits.
+//
+// Reproduces the race deterministically by setting en.expired manually
+// before calling FlushPending (simulating expireEnrichment having
+// claimed but not yet committed).
+func TestTryEnrichWithFallback_ExpireFlushRace(t *testing.T) {
+	setupTestDB(t)
+	guildID := snowflake.ID(1307)
+	guildEnabled(t, guildID)
+
+	target := snowflake.ID(13071)
+	moderator := snowflake.ID(13072)
+
+	fallback := Entry{
+		GuildID:    guildID,
+		Category:   CategoryMember,
+		EventType:  EventMemberNickChange,
+		ActorID:    &moderator,
+		ActorKind:  ActorUser,
+		TargetID:   &target,
+		TargetKind: TargetUser,
+		Source:     SourceGateway,
+		Details:    map[string]any{"nick_before": "old", "nick_after": "new"},
+	}
+
+	TryEnrichWithFallback(guildID, EventMemberNickChange, &target, nil,
+		&moderator, ActorUser, "modUser", "", MatchFirst, 0, fallback)
+
+	// Locate the buffered enrichment and simulate expireEnrichment's
+	// partial progress: en.expired set, but the buffer still contains
+	// the entry. (Real expireEnrichment would release en.mu here and
+	// race for buffer.mu against FlushPending.)
+	pendingBuffer.mu.Lock()
+	var en *pendingEnrichment
+	for _, list := range pendingBuffer.enrichments {
+		if len(list) > 0 {
+			en = list[0]
+			break
+		}
+	}
+	pendingBuffer.mu.Unlock()
+	require.NotNil(t, en, "enrichment should have been buffered")
+
+	en.mu.Lock()
+	en.expired = true
+	en.mu.Unlock()
+
+	// Now run FlushPending. With the buggy "skip if expired" check it
+	// would observe en.expired == true and skip; with the fallbackCommitted
+	// check-and-set it commits the fallback because nobody else has yet.
+	FlushPending()
+
+	// Give any in-flight timer callback a moment to run; it should bail
+	// on en.expired without writing anything (and FlushPending stopped
+	// the timer anyway).
+	time.Sleep(pendingTTL + 100*time.Millisecond)
+
+	assert.EqualValues(t, 1, countRows(t, guildID),
+		"FlushPending must commit fallback even when expireEnrichment claimed it but didn't get to commit")
+}
+
 // MatchAll + fallback is unsupported (would duplicate). The pairing must
 // drop the fallback rather than silently emit two rows.
 func TestTryEnrichWithFallback_MatchAllDropsFallback(t *testing.T) {

--- a/listeners/audit_member.go
+++ b/listeners/audit_member.go
@@ -45,12 +45,17 @@ func OnAuditMemberUpdate(e *events.GuildMemberUpdate) {
 	// yet), OldMember is the zero value: empty role list, nil timeout,
 	// nil nick, zero User.ID. We can't tell whether THIS event changed
 	// anything or just happened to fire for an already-timed-out /
-	// already-nicked member, so emitting any audit row here would falsely
-	// pin a state change to this event's timestamp. Bail entirely; the
-	// missed events on cold cache (rare; cache fills within the first
-	// gateway events) are still recoverable from Discord's native audit
-	// log if a moderator needs to cross-check actions taken during
-	// startup.
+	// already-nicked member, so bailing avoids falsely pinning pre-
+	// existing state to this event's timestamp.
+	//
+	// The cold-cache MODERATOR case is rescued by the native-enrichment
+	// listener: it calls TryEnrichWithFallback, so when no pending entry
+	// arrives (because we bailed here), the buffered enrichment's
+	// fallback Entry is committed at TTL — preserving the row with full
+	// attribution from Discord's Changes payload. Self-actions during
+	// cold cache still get lost (Discord doesn't audit self-changes),
+	// which is acceptable: the same gap exists in Discord's own audit
+	// log.
 	if old.User.ID == 0 {
 		return
 	}

--- a/listeners/audit_native_enrichment.go
+++ b/listeners/audit_native_enrichment.go
@@ -1,6 +1,7 @@
 package listeners
 
 import (
+	"encoding/json"
 	"strconv"
 
 	"github.com/disgoorg/disgo/discord"
@@ -136,13 +137,26 @@ func OnAuditNativeEnrichment(e *events.GuildAuditLogEntryCreate) {
 		// We split by the change key so the right pending event type
 		// gets enriched: timeout / nick / role changes are separate
 		// audit log event types since this last refactor.
+		//
+		// Each TryEnrich call carries a fallback Entry built from the
+		// native Changes payload. On warm cache the gateway pending entry
+		// is consumed inline and the fallback is dropped; on cold cache
+		// (gateway listener bails because it can't diff against zero
+		// state), the buffered enrichment times out and the fallback
+		// commits — preserving moderator-driven nick/role/timeout events
+		// that would otherwise be silently lost post-restart.
 		var target *snowflake.ID
 		if entry.TargetID != nil {
 			id := *entry.TargetID
 			target = &id
 		}
+		var targetUsername string
+		if target != nil {
+			targetUsername = audit.ResolveMemberUsernameOrFetch(e.Client(), guildID, *target)
+		}
 		for _, ev := range memberUpdateEnrichmentTargets(entry.Changes) {
-			audit.TryEnrich(guildID, ev, target, nil, actorPtr, audit.ActorUser, actorUsername, reason, audit.MatchFirst, 0)
+			fallback := buildMemberUpdateFallback(guildID, ev, target, actorPtr, actorUsername, targetUsername, reason, entry.Changes)
+			audit.TryEnrichWithFallback(guildID, ev, target, nil, actorPtr, audit.ActorUser, actorUsername, reason, audit.MatchFirst, 0, fallback)
 		}
 
 	case discord.AuditLogEventMemberKick:
@@ -271,6 +285,100 @@ func isNullJSON(raw []byte) bool {
 // is missing so the buffered enrichment can't latch onto unlimited
 // late-arriving pendings.
 const bulkDeleteCeiling = 100
+
+// buildMemberUpdateFallback constructs an Entry suitable for direct
+// commit when the gateway listener bails (cold cache) and no pending
+// entry will ever arrive to be enriched. Mirrors what the gateway side
+// would have produced from an old/new diff, but built from Discord's
+// native Changes payload — which carries before/after values for every
+// audited field regardless of our member cache state.
+//
+// targetUsername is resolved once at the call site (via ResolveMemberUsernameOrFetch)
+// rather than per-event so a single MemberUpdate with multiple change
+// kinds doesn't pay 2-3× the REST cost.
+func buildMemberUpdateFallback(
+	guildID snowflake.ID,
+	ev audit.EventType,
+	target, actorPtr *snowflake.ID,
+	actorUsername, targetUsername, reason string,
+	changes []discord.AuditLogChange,
+) audit.Entry {
+	details := changesToMemberDetails(changes, ev)
+	if actorUsername != "" {
+		details["actor_username"] = actorUsername
+	}
+	if targetUsername != "" {
+		details["target_username"] = targetUsername
+	}
+	return audit.Entry{
+		GuildID:   guildID,
+		Category:  audit.EventCategory(ev),
+		EventType: ev,
+		ActorID:   actorPtr,
+		ActorKind: audit.ActorUser,
+		TargetID:  target,
+		TargetKind: audit.TargetUser,
+		// The native side produced this row; Log / LogPending normally
+		// fill in the Source, but the fallback path goes through commit
+		// directly. Mark as Gateway since the event is conceptually a
+		// gateway-witnessed change (we just couldn't observe it via
+		// disgo's GuildMemberUpdate due to cold cache) — keeps the row
+		// indistinguishable from a warm-cache emit in viewer filters.
+		Source:  audit.SourceGateway,
+		Reason:  reason,
+		Details: details,
+	}
+}
+
+// changesToMemberDetails extracts the Details payload for a specific
+// member-event type from a native audit log Changes array. Mirrors the
+// keys the gateway listener writes (nick_before / nick_after,
+// roles_added / roles_removed, timeout_until) so the viewer renders
+// fallback rows identically to gateway-witnessed rows.
+//
+// Returns an empty map (not nil) so callers can unconditionally set
+// actor_username / target_username on top.
+func changesToMemberDetails(changes []discord.AuditLogChange, ev audit.EventType) map[string]any {
+	details := map[string]any{}
+	for _, c := range changes {
+		switch c.Key {
+		case discord.AuditLogChangeKeyNick:
+			if ev != audit.EventMemberNickChange {
+				continue
+			}
+			var before, after string
+			_ = json.Unmarshal(c.OldValue, &before)
+			_ = json.Unmarshal(c.NewValue, &after)
+			details["nick_before"] = before
+			details["nick_after"] = after
+		case discord.AuditLogChangeKeyRoleAdd:
+			if ev != audit.EventMemberRoleChange {
+				continue
+			}
+			var added []map[string]any
+			if err := json.Unmarshal(c.NewValue, &added); err == nil && len(added) > 0 {
+				details["roles_added"] = added
+			}
+		case discord.AuditLogChangeKeyRoleRemove:
+			if ev != audit.EventMemberRoleChange {
+				continue
+			}
+			var removed []map[string]any
+			if err := json.Unmarshal(c.NewValue, &removed); err == nil && len(removed) > 0 {
+				details["roles_removed"] = removed
+			}
+		case discord.AuditLogChangeKeyCommunicationDisabledUntil:
+			if ev != audit.EventMemberTimeoutAdd {
+				continue
+			}
+			var until string
+			if err := json.Unmarshal(c.NewValue, &until); err == nil && until != "" {
+				details["timeout_until"] = until
+			}
+		}
+	}
+	return details
+}
 
 // isHandledAuditAction reports whether the listener has a case for this
 // native audit log action type. Used as an early bail-out so we don't

--- a/listeners/audit_native_enrichment.go
+++ b/listeners/audit_native_enrichment.go
@@ -311,12 +311,12 @@ func buildMemberUpdateFallback(
 		details["target_username"] = targetUsername
 	}
 	return audit.Entry{
-		GuildID:   guildID,
-		Category:  audit.EventCategory(ev),
-		EventType: ev,
-		ActorID:   actorPtr,
-		ActorKind: audit.ActorUser,
-		TargetID:  target,
+		GuildID:    guildID,
+		Category:   audit.EventCategory(ev),
+		EventType:  ev,
+		ActorID:    actorPtr,
+		ActorKind:  audit.ActorUser,
+		TargetID:   target,
 		TargetKind: audit.TargetUser,
 		// The native side produced this row; Log / LogPending normally
 		// fill in the Source, but the fallback path goes through commit


### PR DESCRIPTION
Introduce `TryEnrichWithFallback` so the native enrichment listener can supply a pre-built `Entry` alongside its enrichment request. On warm cache the gateway pending entry matches first and the fallback is discarded. On cold cache (gateway listener bails due to missing old member state), the buffered enrichment times out and the fallback is committed — preserving moderator-driven nick, role, and timeout changes that would otherwise be silently lost after a restart.

Key behavioural guarantees enforced and tested:
- Fallback commits on TTL expiry (cold-cache path)
- Fallback is dropped when the gateway entry enriches inline (warm-cache, no duplicate)
- Disabled guilds do not receive backdoor rows via the fallback path
- `MatchAll` + fallback is rejected with a warning (would duplicate)
- Fallback rows carry the correct `Category` for retention pruning and viewer filters
- `FlushPending` on shutdown commits unconsumed fallbacks the same way `expireEnrichment` would at TTL