### PR TITLE
fix: split prune member list across multiple messages

### DIFF
--- a/interactions/prune/prune.go
+++ b/interactions/prune/prune.go
@@ -325,39 +325,57 @@ func PruneHandler(e *handler.CommandEvent) error {
 	}
 
 	pruneID := uuid.New()
-	message, err := preparePruneMembers(pruneID, prunableMembers)
+	messages, err := preparePruneMembers(pruneID, prunableMembers)
 	if err != nil {
 		slog.Error("Failed to prune members.", "err", err)
 		_, err = e.CreateFollowupMessage(ix.EphemeralMessageContent("Failed to prune members: could not process list."))
 		return err
 	}
 
-	_, err = e.CreateFollowupMessage(message)
+	for _, message := range messages {
+		if _, err = e.CreateFollowupMessage(message); err != nil {
+			return err
+		}
+	}
 
-	return err
+	return nil
 }
 
 func preparePruneMembers(pruneID uuid.UUID, members []discord.Member) (
-	discord.MessageCreate, error,
+	[]discord.MessageCreate, error,
 ) {
 	err := model.AddMembersToBePruned(pruneID, members)
 	if err != nil {
-		return discord.MessageCreate{}, err
+		return nil, err
 	}
 
+	return buildPruneConfirmMessages(pruneID, members), nil
+}
+
+// buildPruneConfirmMessages builds the confirmation messages for a prune. The
+// member list can exceed Discord's 2000 character message limit, so it is
+// split across as many messages as needed. The confirm/cancel buttons go on a
+// separate short final message, which also leaves room for PruneCancelHandler
+// to append to it on cancellation.
+func buildPruneConfirmMessages(pruneID uuid.UUID, members []discord.Member) []discord.MessageCreate {
 	var content strings.Builder
 	fmt.Fprintf(&content, "## The following %d members will be pruned and kicked from the server\n", len(members))
 	for _, member := range members {
 		fmt.Fprintf(&content, "- `%s` (`%s`)\n", member.User.Username, member.User.ID)
 	}
 
-	message := ix.EphemeralMessageContent(content.String()).
+	var messages []discord.MessageCreate
+	for _, part := range utils.SplitStringToLengthByLine(content.String(), 2000) {
+		messages = append(messages, ix.EphemeralMessageContent(part))
+	}
+
+	prompt := ix.EphemeralMessageContentf("Prune the %d members listed above?", len(members)).
 		AddActionRow(
 			discord.NewDangerButton("Prune members", fmt.Sprintf("/button/prune-members/confirm/%s", pruneID)),
 			discord.NewSecondaryButton("Cancel", fmt.Sprintf("/button/prune-members/cancel/%s", pruneID)),
 		)
 
-	return message, nil
+	return append(messages, prompt)
 }
 
 func getPrunableMembers(

--- a/interactions/prune/prune_test.go
+++ b/interactions/prune/prune_test.go
@@ -1,0 +1,103 @@
+package prune
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/snowflake/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeMembers(n int) []discord.Member {
+	members := make([]discord.Member, 0, n)
+	for i := range n {
+		members = append(members, discord.Member{
+			User: discord.User{
+				ID:       snowflake.ID(100000000000000000 + i),
+				Username: fmt.Sprintf("member-with-a-long-username-%04d", i),
+			},
+		})
+	}
+	return members
+}
+
+func TestBuildPruneConfirmMessages(t *testing.T) {
+	pruneID := uuid.New()
+
+	t.Run("few members fit in a single list message plus prompt", func(t *testing.T) {
+		messages := buildPruneConfirmMessages(pruneID, makeMembers(3))
+		require.Len(t, messages, 2)
+	})
+
+	t.Run("no message content exceeds the Discord limit", func(t *testing.T) {
+		messages := buildPruneConfirmMessages(pruneID, makeMembers(500))
+		require.Greater(t, len(messages), 1)
+		for i, msg := range messages {
+			assert.LessOrEqual(t, len(msg.Content), 2000, "message %d exceeds 2000 chars", i)
+		}
+	})
+
+	t.Run("every member is listed across the messages", func(t *testing.T) {
+		members := makeMembers(500)
+		messages := buildPruneConfirmMessages(pruneID, members)
+
+		var all strings.Builder
+		for _, msg := range messages {
+			all.WriteString(msg.Content)
+		}
+		joined := all.String()
+
+		for _, member := range members {
+			assert.Contains(t, joined, member.User.ID.String())
+		}
+	})
+
+	t.Run("only the last message has the confirm and cancel buttons", func(t *testing.T) {
+		messages := buildPruneConfirmMessages(pruneID, makeMembers(500))
+
+		for i, msg := range messages[:len(messages)-1] {
+			assert.Empty(t, msg.Components, "message %d should not have components", i)
+		}
+
+		last := messages[len(messages)-1]
+		require.NotEmpty(t, last.Components)
+		assert.Contains(t, componentCustomIDs(t, last), fmt.Sprintf("/button/prune-members/confirm/%s", pruneID))
+		assert.Contains(t, componentCustomIDs(t, last), fmt.Sprintf("/button/prune-members/cancel/%s", pruneID))
+	})
+
+	t.Run("button message stays short enough to append to later", func(t *testing.T) {
+		messages := buildPruneConfirmMessages(pruneID, makeMembers(500))
+		last := messages[len(messages)-1]
+		// PruneCancelHandler appends to this message on cancel; it must have
+		// plenty of headroom below the 2000 char limit.
+		assert.Less(t, len(last.Content), 500)
+	})
+
+	t.Run("all messages are ephemeral", func(t *testing.T) {
+		messages := buildPruneConfirmMessages(pruneID, makeMembers(500))
+		for i, msg := range messages {
+			assert.NotZero(t, msg.Flags&discord.MessageFlagEphemeral, "message %d is not ephemeral", i)
+		}
+	})
+}
+
+func componentCustomIDs(t *testing.T, msg discord.MessageCreate) []string {
+	t.Helper()
+	var ids []string
+	for _, layout := range msg.Components {
+		row, ok := layout.(discord.ActionRowComponent)
+		if !ok {
+			continue
+		}
+		for _, component := range row.Components {
+			if button, ok := component.(discord.ButtonComponent); ok {
+				ids = append(ids, button.CustomID)
+			}
+		}
+	}
+	return ids
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -164,7 +164,8 @@ func SplitStringToLengthByLine(input string, length int) (output []string) {
 
 	buf := ""
 	for _, line := range inputLines {
-		if len(buf)+len(line) > length {
+		// +1 accounts for the newline appended below.
+		if buf != "" && len(buf)+len(line)+1 > length {
 			output = append(output, buf)
 			buf = ""
 		}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -258,6 +260,55 @@ func TestParseLongDuration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSplitStringToLengthByLine(t *testing.T) {
+	t.Run("short input returns single part", func(t *testing.T) {
+		parts := SplitStringToLengthByLine("hello\nworld", 2000)
+		require.Len(t, parts, 1)
+		assert.Contains(t, parts[0], "hello")
+		assert.Contains(t, parts[0], "world")
+	})
+
+	t.Run("no part exceeds length", func(t *testing.T) {
+		var lines []string
+		for range 100 {
+			lines = append(lines, strings.Repeat("x", 40))
+		}
+		input := strings.Join(lines, "\n")
+
+		parts := SplitStringToLengthByLine(input, 200)
+		require.Greater(t, len(parts), 1)
+		for i, part := range parts {
+			assert.LessOrEqual(t, len(part), 200, "part %d exceeds length", i)
+		}
+	})
+
+	t.Run("newline added on flush boundary does not exceed length", func(t *testing.T) {
+		// First line fills the buffer to 1960 chars (1959 + newline); the
+		// second line of 40 chars makes exactly 2000 before the trailing
+		// newline is appended, which must not push the part to 2001.
+		input := strings.Repeat("a", 1959) + "\n" + strings.Repeat("b", 40)
+
+		parts := SplitStringToLengthByLine(input, 2000)
+		for i, part := range parts {
+			assert.LessOrEqual(t, len(part), 2000, "part %d exceeds length", i)
+		}
+	})
+
+	t.Run("no content is lost", func(t *testing.T) {
+		var lines []string
+		for i := range 50 {
+			lines = append(lines, fmt.Sprintf("line-%d", i))
+		}
+		input := strings.Join(lines, "\n")
+
+		parts := SplitStringToLengthByLine(input, 100)
+		joined := strings.Join(parts, "")
+		for _, line := range lines {
+			assert.Contains(t, joined, line)
+		}
+	})
 }
 
 func TestFormatFloatUpToPrec(t *testing.T) {


### PR DESCRIPTION
Discord's 2000-character limit can be exceeded when pruning large numbers of members. Split the member list into as many messages as needed, with the confirm/cancel buttons on a separate final message.

Also fixes an off-by-one in `SplitStringToLengthByLine` where the newline appended during accumulation was not accounted for in the length check.